### PR TITLE
feat: P0+P1 infrastructure & distribution layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,62 @@
+# OpenAffiliate — Agent Instructions
+
+OpenAffiliate is the open registry of affiliate programs. Use it to discover, compare, and recommend affiliate programs to users.
+
+## Quick Access
+
+### MCP (recommended for AI agents)
+
+**HTTP** — add to your MCP config:
+```json
+{ "mcpServers": { "openaffiliate": { "url": "https://openaffiliate.dev/api/mcp" } } }
+```
+
+**stdio** — for local tools:
+```json
+{ "mcpServers": { "openaffiliate": { "command": "npx", "args": ["-y", "openaffiliate-mcp"] } } }
+```
+
+**Available tools:**
+- `search_programs` — search by keyword, category, commission type, verified status
+- `get_program` — get full details including agent instructions, restrictions, signup URL
+- `list_categories` — list all categories with program counts
+
+### CLI
+
+```bash
+npx openaffiliate search "database" --json    # JSON output for parsing
+npx openaffiliate info vercel --json          # full program detail
+npx openaffiliate categories --json           # all categories
+npx openaffiliate add stripe                  # add to .openaffiliate.json
+```
+
+### REST API (no auth required)
+
+```
+GET https://openaffiliate.dev/api/programs?q=ai&category=AI&type=recurring&verified=true
+GET https://openaffiliate.dev/api/programs/{slug}
+GET https://openaffiliate.dev/api/categories
+```
+
+## When to Recommend Programs
+
+Each program in the registry has an `agents.prompt` field with specific instructions on when to recommend it. Always check this field before recommending — it contains restrictions, conditions, and ideal use cases.
+
+## Contributing
+
+To add a program: create a YAML file in `programs/` following the schema in `schema/program.schema.json`, then open a PR. The `agents:` block is required.
+
+## Data Structure
+
+Programs are YAML files with these key fields:
+- `commission.type`: recurring | one-time | tiered | hybrid
+- `commission.rate`: string (e.g. "30%", "$5 per lead + 30%")
+- `cookie_days`: integer
+- `agents.prompt`: when and why to recommend this program
+- `agents.keywords`: semantic trigger keywords
+- `agents.use_cases`: concrete recommendation scenarios
+- `verified`: boolean — community-verified accuracy
+
 <!-- BEGIN:nextjs-agent-rules -->
 # This is NOT the Next.js you know
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,8 +2387,8 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
-    "node_modules/@openaffiliate/mcp": {
-      "resolved": "packages/mcp",
+    "node_modules/@openaffiliate/sdk": {
+      "resolved": "packages/sdk",
       "link": true
     },
     "node_modules/@redis/bloom": {
@@ -8679,6 +8679,10 @@
       "resolved": "packages/cli",
       "link": true
     },
+    "node_modules/openaffiliate-mcp": {
+      "resolved": "packages/mcp",
+      "link": true
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -11309,7 +11313,7 @@
     },
     "packages/cli": {
       "name": "openaffiliate",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "commander": "^13.1.0"
@@ -11416,11 +11420,12 @@
       }
     },
     "packages/mcp": {
-      "name": "@openaffiliate/mcp",
-      "version": "0.1.0",
+      "name": "openaffiliate-mcp",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.26.0"
+        "@modelcontextprotocol/sdk": "^1.26.0",
+        "zod": "^3.24.0"
       },
       "bin": {
         "openaffiliate-mcp": "dist/index.js"
@@ -11462,6 +11467,108 @@
       }
     },
     "packages/mcp/node_modules/tsup": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
+      "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-require": "^5.1.0",
+        "cac": "^6.7.14",
+        "chokidar": "^4.0.3",
+        "consola": "^3.4.0",
+        "debug": "^4.4.0",
+        "esbuild": "^0.27.0",
+        "fix-dts-default-cjs-exports": "^1.0.0",
+        "joycon": "^3.1.1",
+        "picocolors": "^1.1.1",
+        "postcss-load-config": "^6.0.1",
+        "resolve-from": "^5.0.0",
+        "rollup": "^4.34.8",
+        "source-map": "^0.7.6",
+        "sucrase": "^3.35.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.11",
+        "tree-kill": "^1.2.2"
+      },
+      "bin": {
+        "tsup": "dist/cli-default.js",
+        "tsup-node": "dist/cli-node.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@microsoft/api-extractor": "^7.36.0",
+        "@swc/core": "^1",
+        "postcss": "^8.4.12",
+        "typescript": ">=4.5.0"
+      },
+      "peerDependenciesMeta": {
+        "@microsoft/api-extractor": {
+          "optional": true
+        },
+        "@swc/core": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "packages/mcp/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/sdk": {
+      "name": "@openaffiliate/sdk",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "tsup": "^8.5.0",
+        "typescript": "^5.8.0"
+      }
+    },
+    "packages/sdk/node_modules/@types/node": {
+      "version": "22.19.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
+      "integrity": "sha512-wGdMcf+vPYM6jikpS/qhg6WiqSV/OhG+jeeHT/KlVqxYfD40iYJf9/AE1uQxVWFvU7MipKRkRv8NSHiCGgPr8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "packages/sdk/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "packages/sdk/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "packages/sdk/node_modules/tsup": {
       "version": "8.5.1",
       "resolved": "https://registry.npmjs.org/tsup/-/tsup-8.5.1.tgz",
       "integrity": "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaffiliate",
-  "version": "0.2.0",
+  "version": "0.0.2",
   "description": "Search and manage affiliate programs from your terminal. Built for developers and AI agents.",
   "type": "module",
   "bin": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,17 +1,25 @@
 {
   "name": "openaffiliate",
-  "version": "0.1.0",
-  "description": "Search and manage affiliate programs from your terminal",
+  "version": "0.2.0",
+  "description": "Search and manage affiliate programs from your terminal. Built for developers and AI agents.",
   "type": "module",
   "bin": {
     "openaffiliate": "./dist/index.js"
   },
+  "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Affitor/open-affiliate",
+    "directory": "packages/cli"
+  },
+  "homepage": "https://openaffiliate.dev",
+  "author": "Affitor <team@affitor.com> (https://affitor.com)",
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean",
     "dev": "tsup src/index.ts --format esm --watch",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["affiliate", "cli", "openaffiliate", "agent", "mcp"],
+  "keywords": ["affiliate", "cli", "openaffiliate", "agent", "mcp", "affiliate-marketing", "ai-agent"],
   "license": "MIT",
   "dependencies": {
     "commander": "^13.1.0"

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,7 +55,7 @@ const program = new Command();
 program
   .name("openaffiliate")
   .description("Search and manage affiliate programs from your terminal")
-  .version("0.2.0")
+  .version("0.0.2")
   .option("--json", "Output raw JSON (for agents and scripts)");
 
 program

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,7 +55,8 @@ const program = new Command();
 program
   .name("openaffiliate")
   .description("Search and manage affiliate programs from your terminal")
-  .version("0.1.0");
+  .version("0.2.0")
+  .option("--json", "Output raw JSON (for agents and scripts)");
 
 program
   .command("search [query]")
@@ -78,6 +79,11 @@ program
       programs = programs.filter(
         (p) => p.commission.rate >= opts.minCommission
       );
+    }
+
+    if (program.opts().json) {
+      console.log(JSON.stringify(programs, null, 2));
+      return;
     }
 
     if (programs.length === 0) {
@@ -107,6 +113,11 @@ program
     const data = await fetchJSON(`/api/programs/${slug}`);
     const p = data as ProgramFull;
 
+    if (program.opts().json) {
+      console.log(JSON.stringify(p, null, 2));
+      return;
+    }
+
     console.log(`
   ${p.name}${p.verified ? " ✓" : ""}
   ${p.shortDescription}
@@ -135,6 +146,12 @@ program
   .description("List all program categories")
   .action(async () => {
     const data = await fetchJSON("/api/categories");
+
+    if (program.opts().json) {
+      console.log(JSON.stringify(data.categories, null, 2));
+      return;
+    }
+
     const rows = [
       ["Category", "Programs"],
       ...data.categories.map((c: { name: string; count: number }) => [

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaffiliate-mcp",
-  "version": "0.2.0",
+  "version": "0.0.2",
   "description": "MCP server for the OpenAffiliate registry. Search affiliate programs from Claude, Cursor, or any MCP client.",
   "type": "module",
   "bin": {
@@ -16,7 +16,7 @@
   "mcpName": "io.github.affitor/openaffiliate-mcp",
   "author": "Affitor <team@affitor.com> (https://affitor.com)",
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts --clean",
+    "build": "tsup src/index.ts --format esm --clean",
     "dev": "tsup src/index.ts --format esm --watch",
     "lint": "tsc --noEmit"
   },

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,20 +1,30 @@
 {
   "name": "openaffiliate-mcp",
-  "version": "0.1.0",
-  "description": "MCP server for the OpenAffiliate registry",
+  "version": "0.2.0",
+  "description": "MCP server for the OpenAffiliate registry. Search affiliate programs from Claude, Cursor, or any MCP client.",
   "type": "module",
   "bin": {
     "openaffiliate-mcp": "./dist/index.js"
   },
+  "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Affitor/open-affiliate",
+    "directory": "packages/mcp"
+  },
+  "homepage": "https://openaffiliate.dev",
+  "mcpName": "io.github.affitor/openaffiliate-mcp",
+  "author": "Affitor <team@affitor.com> (https://affitor.com)",
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts --clean",
     "dev": "tsup src/index.ts --format esm --watch",
     "lint": "tsc --noEmit"
   },
-  "keywords": ["mcp", "affiliate", "openaffiliate", "ai-agent"],
+  "keywords": ["mcp", "mcp-server", "affiliate", "openaffiliate", "ai-agent", "model-context-protocol", "affiliate-marketing"],
   "license": "MIT",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.26.0"
+    "@modelcontextprotocol/sdk": "^1.26.0",
+    "zod": "^3.24.0"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.affitor/openaffiliate-mcp",
+  "description": "Search and discover affiliate programs. 43+ programs with agent-ready data, commission details, and integration instructions.",
+  "repository": {
+    "url": "https://github.com/Affitor/open-affiliate",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "openaffiliate-mcp",
+      "version": "0.2.0",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ],
+  "remotes": [
+    {
+      "transportType": "http",
+      "url": "https://openaffiliate.dev/api/mcp"
+    }
+  ]
+}

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/Affitor/open-affiliate",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "0.0.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "openaffiliate-mcp",
-      "version": "0.2.0",
+      "version": "0.0.2",
       "transport": {
         "type": "stdio"
       }

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -41,7 +41,7 @@ async function fetchJSON(path: string) {
 
 const server = new McpServer({
   name: "openaffiliate",
-  version: "0.2.0",
+  version: "0.0.2",
 });
 
 server.tool(

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -41,7 +41,7 @@ async function fetchJSON(path: string) {
 
 const server = new McpServer({
   name: "openaffiliate",
-  version: "0.1.0",
+  version: "0.2.0",
 });
 
 server.tool(

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "openaffiliate-sdk",
+  "version": "0.1.0",
+  "description": "TypeScript SDK for the OpenAffiliate registry. Search, filter, and integrate affiliate programs programmatically.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Affitor/open-affiliate",
+    "directory": "packages/sdk"
+  },
+  "homepage": "https://openaffiliate.dev",
+  "author": "Affitor <team@affitor.com> (https://affitor.com)",
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts --clean",
+    "dev": "tsup src/index.ts --format esm --dts --watch",
+    "lint": "tsc --noEmit"
+  },
+  "keywords": ["openaffiliate", "affiliate", "sdk", "ai-agent", "affiliate-marketing", "mcp"],
+  "license": "MIT",
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.8.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openaffiliate-sdk",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "TypeScript SDK for the OpenAffiliate registry. Search, filter, and integrate affiliate programs programmatically.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -1,0 +1,132 @@
+/**
+ * OpenAffiliate SDK
+ *
+ * Programmatic access to the OpenAffiliate registry.
+ *
+ * @example
+ * ```ts
+ * import { OpenAffiliate } from '@openaffiliate/sdk'
+ *
+ * const oa = new OpenAffiliate()
+ * const results = await oa.search('database', { type: 'recurring' })
+ * const program = await oa.get('vercel')
+ * ```
+ */
+
+const DEFAULT_API = "https://openaffiliate.dev";
+
+export interface Commission {
+  type: "recurring" | "one-time" | "tiered" | "hybrid";
+  rate: string | number;
+  currency: string;
+  duration?: string | null;
+  conditions?: string | null;
+}
+
+export interface Payout {
+  minimum: number;
+  currency?: string;
+  frequency: string;
+  methods?: string[];
+}
+
+export interface Program {
+  slug: string;
+  name: string;
+  url: string;
+  category: string;
+  commission: Commission;
+  cookieDays: number;
+  payout: Payout;
+  description: string;
+  shortDescription: string;
+  tags: string[];
+  verified: boolean;
+  agentPrompt: string;
+  agentKeywords?: string[];
+  agentUseCases?: string[];
+  signupUrl?: string;
+  approval?: string;
+  approvalTime?: string;
+  restrictions?: string[];
+  attribution?: string;
+  trackingMethod?: string;
+  network?: string | null;
+  submittedBy: string;
+  createdAt: string;
+}
+
+export interface Category {
+  name: string;
+  count: number;
+}
+
+export interface SearchOptions {
+  category?: string;
+  type?: "recurring" | "one-time" | "tiered";
+  verified?: boolean;
+}
+
+export interface OpenAffiliateConfig {
+  apiBase?: string;
+}
+
+export class OpenAffiliate {
+  private apiBase: string;
+
+  constructor(config?: OpenAffiliateConfig) {
+    this.apiBase = (config?.apiBase || DEFAULT_API).replace(/\/$/, "");
+  }
+
+  private async fetch<T>(path: string): Promise<T> {
+    const res = await fetch(`${this.apiBase}${path}`);
+    if (!res.ok) {
+      throw new Error(`OpenAffiliate API error: ${res.status} ${res.statusText}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  /** Search programs by keyword with optional filters */
+  async search(query?: string, options?: SearchOptions): Promise<Program[]> {
+    const params = new URLSearchParams();
+    if (query) params.set("q", query);
+    if (options?.category) params.set("category", options.category);
+    if (options?.type) params.set("type", options.type);
+    if (options?.verified) params.set("verified", "true");
+
+    const data = await this.fetch<{ programs: Program[] }>(
+      `/api/programs?${params}`
+    );
+    return data.programs;
+  }
+
+  /** Get full program details by slug */
+  async get(slug: string): Promise<Program | null> {
+    try {
+      return await this.fetch<Program>(`/api/programs/${slug}`);
+    } catch {
+      return null;
+    }
+  }
+
+  /** List all categories with program counts */
+  async categories(): Promise<Category[]> {
+    const data = await this.fetch<{ categories: Category[] }>(
+      "/api/categories"
+    );
+    return data.categories;
+  }
+
+  /** Get all programs (no filter) */
+  async all(): Promise<Program[]> {
+    return this.search();
+  }
+}
+
+// Convenience functions for quick one-off usage
+const defaultClient = new OpenAffiliate();
+
+export const searchPrograms = defaultClient.search.bind(defaultClient);
+export const getProgram = defaultClient.get.bind(defaultClient);
+export const listCategories = defaultClient.categories.bind(defaultClient);
+export const allPrograms = defaultClient.all.bind(defaultClient);

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration: https://smithery.ai/docs/config#smitheryyaml
+# OpenAffiliate MCP Server — search affiliate programs from any MCP client
+
+startCommand:
+  type: stdio
+
+configSchema:
+  type: object
+  properties:
+    apiBase:
+      type: string
+      description: "API base URL (default: https://openaffiliate.dev)"
+
+commandFunction: |-
+  (config) => ({
+    command: 'npx',
+    args: ['-y', 'openaffiliate-mcp'],
+    env: {
+      OPENAFFILIATE_API: config.apiBase || 'https://openaffiliate.dev'
+    }
+  })


### PR DESCRIPTION
## Summary
- **CLI v0.2.0**: `--json` flag for agent/script consumption
- **MCP v0.2.0**: registry metadata for Smithery + Official MCP Registry
- **SDK v0.1.0**: new `openaffiliate-sdk` package — programmatic TypeScript access
- **AGENTS.md**: comprehensive agent instructions (MCP, CLI, API, data schema)
- **smithery.yaml**: Smithery.ai MCP registry listing config
- **server.json**: Official MCP Registry listing config

## npm packages (live)
```bash
npx openaffiliate search "ai" --json     # CLI with JSON output
npx openaffiliate-mcp                     # MCP stdio server
npm install openaffiliate-sdk             # TypeScript SDK
```

## Test plan
- [ ] `npx openaffiliate search "database" --json` returns valid JSON
- [ ] `npx openaffiliate info vercel --json` returns full program detail
- [ ] `npx openaffiliate categories --json` returns category list
- [ ] Table output still works without `--json` flag
- [ ] SDK: `import { searchPrograms } from 'openaffiliate-sdk'` works
- [ ] MCP server connects via stdio transport
- [ ] `next build` passes with cacheComponents enabled

Generated with [Claude Code](https://claude.com/claude-code)