### PR TITLE
fix: limit commission text to 2 lines in rankings

### DIFF
--- a/src/app/rankings/page.tsx
+++ b/src/app/rankings/page.tsx
@@ -304,7 +304,7 @@ function ProgramsTable({
                   </Link>
                 </td>
                 <td className="py-3 px-3 hidden sm:table-cell">
-                  <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400">
+                  <span className="text-sm font-semibold text-emerald-600 dark:text-emerald-400 line-clamp-2">
                     {program.commission.rate}
                   </span>
                 </td>


### PR DESCRIPTION
## Summary
- Added `line-clamp-2` to commission rate text in rankings table
- Prevents long rates (e.g. "75-125% CPA + 25% annual") from taking 3+ lines

## Test plan
- [ ] Check Surfer SEO row — commission should be max 2 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)