### PR TITLE
feat: clickable network rows in rankings

### DIFF
--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -184,6 +184,9 @@ function ProgramsContent() {
   const [selectedType, setSelectedType] = useState(
     searchParams.get("type") ?? ""
   );
+  const [selectedNetwork, setSelectedNetwork] = useState(
+    searchParams.get("network") ?? ""
+  );
   const [sort, setSort] = useState<SortOption>(
     (searchParams.get("sort") as SortOption) ?? "relevance"
   );
@@ -206,18 +209,19 @@ function ProgramsContent() {
   );
 
   const updateFilters = useCallback(
-    (updates: Partial<{ q: string; category: string; type: string; sort: string }>) => {
+    (updates: Partial<{ q: string; category: string; type: string; network: string; sort: string }>) => {
       const next = {
         q: updates.q ?? query,
         category: updates.category ?? selectedCategory,
         type: updates.type ?? selectedType,
+        network: updates.network ?? selectedNetwork,
         sort: updates.sort ?? sort,
       };
       // Don't include defaults in URL
       if (next.sort === "relevance") next.sort = "";
       syncUrl(next);
     },
-    [query, selectedCategory, selectedType, sort, syncUrl]
+    [query, selectedCategory, selectedType, selectedNetwork, sort, syncUrl]
   );
 
   const filtered = useMemo(
@@ -226,9 +230,10 @@ function ProgramsContent() {
         query: query || undefined,
         category: selectedCategory || undefined,
         commissionType: selectedType || undefined,
+        network: selectedNetwork || undefined,
         sort,
       }),
-    [query, selectedCategory, selectedType, sort]
+    [query, selectedCategory, selectedType, selectedNetwork, sort]
   );
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
@@ -262,16 +267,22 @@ function ProgramsContent() {
     setPageSize(size);
     setPage(1);
   };
+  const handleNetwork = (net: string) => {
+    setSelectedNetwork(net);
+    setPage(1);
+    updateFilters({ network: net });
+  };
   const clearAll = () => {
     setQuery("");
     setSelectedCategory("");
     setSelectedType("");
+    setSelectedNetwork("");
     setSort("relevance");
     setPage(1);
     syncUrl({});
   };
 
-  const hasActiveFilters = !!(query || selectedCategory || selectedType);
+  const hasActiveFilters = !!(query || selectedCategory || selectedType || selectedNetwork);
 
   // Category options with counts
   const categoryOptions = [
@@ -442,6 +453,15 @@ function ProgramsContent() {
                 className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               >
                 {COMMISSION_TYPE_LABELS[selectedType] ?? selectedType}
+                <X className="h-3 w-3" />
+              </button>
+            )}
+            {selectedNetwork && (
+              <button
+                onClick={() => handleNetwork("")}
+                className="inline-flex items-center gap-1 rounded-md border border-border/50 bg-muted/40 px-2 py-0.5 text-[11px] text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              >
+                {selectedNetwork}
                 <X className="h-3 w-3" />
               </button>
             )}

--- a/src/app/rankings/page.tsx
+++ b/src/app/rankings/page.tsx
@@ -378,13 +378,14 @@ function NetworksTable() {
             {stats.map((row, i) => (
               <tr
                 key={row.network}
-                className="border-t border-border/20 hover:bg-muted/20 transition-colors"
+                className="border-t border-border/20 hover:bg-muted/20 transition-colors cursor-pointer group"
+                onClick={() => window.location.href = `/programs?network=${encodeURIComponent(row.network)}`}
               >
                 <td className="py-3 px-3 text-center">
                   <RankBadge rank={i + 1} />
                 </td>
                 <td className="py-3 px-3">
-                  <span className="text-sm font-medium">
+                  <span className="text-sm font-medium group-hover:text-emerald-600 dark:group-hover:text-emerald-400 transition-colors">
                     {formatNetworkName(row.network)}
                   </span>
                 </td>
@@ -406,6 +407,7 @@ function NetworksTable() {
                 <td className="py-3 px-3 hidden md:table-cell">
                   <Link
                     href={`/programs/${row.topProgram.slug}`}
+                    onClick={(e) => e.stopPropagation()}
                     className="flex items-center gap-2 hover:text-emerald-600 dark:hover:text-emerald-400 transition-colors"
                   >
                     <ProgramLogo

--- a/src/lib/programs.ts
+++ b/src/lib/programs.ts
@@ -114,6 +114,7 @@ export interface SearchOptions {
   query?: string
   category?: string
   commissionType?: string
+  network?: string
   sort?: SortOption
   verified?: boolean
 }
@@ -143,6 +144,10 @@ export function searchPrograms(queryOrOptions: string | SearchOptions, category?
 
   if (opts.commissionType) {
     results = results.filter((p) => p.commission.type === opts.commissionType)
+  }
+
+  if (opts.network) {
+    results = results.filter((p) => (p.network ?? "In-house") === opts.network)
   }
 
   if (opts.verified) {


### PR DESCRIPTION
## Summary
- Network rows in Rankings tab are now clickable → navigates to `/programs?network=X`
- Added `network` filter support to `searchPrograms()` and Programs page URL params
- Network filter chip appears in active filters with clear button
- Top Program link still works independently (stopPropagation)

## Test plan
- [ ] Click "Partnerstack" row → goes to `/programs?network=Partnerstack` showing 310 programs
- [ ] Click "In House" → shows 23 programs
- [ ] Network filter chip shows and can be cleared
- [ ] Top Program link still navigates to program detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)