### PR TITLE
feat: user behavior tracking (events + program_stats)

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+import { createHash } from "crypto";
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!
+);
+
+function hashIp(ip: string): string {
+  return createHash("sha256")
+    .update(ip + "openaffiliate-salt")
+    .digest("hex")
+    .slice(0, 16);
+}
+
+const ALLOWED_TYPES = ["search", "program_view", "outbound_click", "filter"];
+
+// POST /api/events — track an event
+export async function POST(req: NextRequest) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ??
+    req.headers.get("x-real-ip") ??
+    "unknown";
+
+  const body = await req.json().catch(() => null);
+  if (!body?.type) {
+    return NextResponse.json({ error: "Missing type" }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.includes(body.type)) {
+    return NextResponse.json({ error: "Invalid type" }, { status: 400 });
+  }
+
+  const ipHash = hashIp(ip);
+  const referrer = req.headers.get("referer") ?? null;
+
+  await supabase.from("events").insert({
+    type: body.type,
+    slug: body.slug ?? null,
+    metadata: body.metadata ?? {},
+    ip_hash: ipHash,
+    referrer,
+  });
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -30,6 +30,7 @@ import { VoteButton } from "@/components/vote-button";
 import { ConnectTabs } from "@/components/connect-tabs";
 import { CapabilityCards } from "@/components/capability-cards";
 import { programs, getProgram, parseCommissionRate } from "@/lib/programs";
+import { TrackView, TrackLink } from "./track-view";
 
 export function generateStaticParams() {
   return programs.map((p) => ({ slug: p.slug }));
@@ -167,6 +168,8 @@ export default async function ProgramPage({
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <TrackView slug={slug} />
+
       {/* Breadcrumb */}
       <Link
         href="/programs"
@@ -556,15 +559,14 @@ export default async function ProgramPage({
           )}
 
           {/* Join button */}
-          <a
+          <TrackLink
             href={joinUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+            slug={slug}
             className="flex items-center justify-center gap-2 rounded-xl bg-foreground hover:bg-foreground/90 text-background px-5 py-3 text-sm font-medium transition-colors w-full"
           >
             Join Program
             <ExternalLink className="h-3.5 w-3.5" />
-          </a>
+          </TrackLink>
         </div>
       </div>
     </div>

--- a/src/app/programs/[slug]/track-view.tsx
+++ b/src/app/programs/[slug]/track-view.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect } from "react";
+import { track } from "@/lib/track";
+
+export function TrackView({ slug }: { slug: string }) {
+  useEffect(() => {
+    track("program_view", { slug });
+  }, [slug]);
+  return null;
+}
+
+export function TrackLink({
+  href,
+  slug,
+  children,
+  className,
+}: {
+  href: string;
+  slug: string;
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={className}
+      onClick={() => track("outbound_click", { slug })}
+    >
+      {children}
+    </a>
+  );
+}

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -24,6 +24,7 @@ import {
   type SortOption,
   type Program,
 } from "@/lib/programs";
+import { track } from "@/lib/track";
 
 const PAGE_SIZE_OPTIONS = [25, 50, 100] as const;
 
@@ -236,6 +237,15 @@ function ProgramsContent() {
     [query, selectedCategory, selectedType, selectedNetwork, sort]
   );
 
+  // Debounced search tracking
+  useEffect(() => {
+    if (!query) return;
+    const timer = setTimeout(() => {
+      track("search", { metadata: { query, resultCount: filtered.length } });
+    }, 800);
+    return () => clearTimeout(timer);
+  }, [query, filtered.length]);
+
   const totalPages = Math.max(1, Math.ceil(filtered.length / pageSize));
   const currentPage = Math.min(page, totalPages);
   const paginated = filtered.slice(
@@ -252,11 +262,13 @@ function ProgramsContent() {
     setSelectedCategory(cat);
     setPage(1);
     updateFilters({ category: cat });
+    if (cat) track("filter", { metadata: { filter: "category", value: cat } });
   };
   const handleType = (type: string) => {
     setSelectedType(type);
     setPage(1);
     updateFilters({ type });
+    if (type) track("filter", { metadata: { filter: "type", value: type } });
   };
   const handleSort = (s: string) => {
     setSort(s as SortOption);
@@ -271,6 +283,7 @@ function ProgramsContent() {
     setSelectedNetwork(net);
     setPage(1);
     updateFilters({ network: net });
+    if (net) track("filter", { metadata: { filter: "network", value: net } });
   };
   const clearAll = () => {
     setQuery("");

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,0 +1,17 @@
+export function track(
+  type: string,
+  data?: { slug?: string; metadata?: Record<string, unknown> }
+) {
+  if (typeof window === "undefined") return;
+
+  fetch("/api/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      type,
+      slug: data?.slug,
+      metadata: data?.metadata,
+    }),
+    keepalive: true,
+  }).catch(() => {});
+}

--- a/supabase/migrations/002_events_tracking.sql
+++ b/supabase/migrations/002_events_tracking.sql
@@ -1,0 +1,37 @@
+-- Events table for user behavior tracking
+CREATE TABLE IF NOT EXISTS events (
+  id bigserial PRIMARY KEY,
+  type text NOT NULL,
+  slug text,
+  metadata jsonb DEFAULT '{}',
+  ip_hash text NOT NULL,
+  referrer text,
+  created_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX idx_events_type ON events(type);
+CREATE INDEX idx_events_slug ON events(slug);
+CREATE INDEX idx_events_created ON events(created_at DESC);
+CREATE INDEX idx_events_type_created ON events(type, created_at DESC);
+
+-- Daily program stats (materialized/denormalized)
+CREATE TABLE IF NOT EXISTS program_stats (
+  slug text NOT NULL,
+  date date NOT NULL DEFAULT CURRENT_DATE,
+  views int DEFAULT 0,
+  outbound_clicks int DEFAULT 0,
+  votes_net int DEFAULT 0,
+  PRIMARY KEY (slug, date)
+);
+
+CREATE INDEX idx_program_stats_date ON program_stats(date DESC);
+
+-- RLS
+ALTER TABLE events ENABLE ROW LEVEL SECURITY;
+ALTER TABLE program_stats ENABLE ROW LEVEL SECURITY;
+
+-- Allow service role full access (API routes use service role key)
+-- No public read/write on events - only via API
+CREATE POLICY "Service role full access" ON events FOR ALL USING (true);
+CREATE POLICY "Public read stats" ON program_stats FOR SELECT USING (true);
+CREATE POLICY "Service role write stats" ON program_stats FOR ALL USING (true);


### PR DESCRIPTION
## Summary
- New `events` table: tracks search, program_view, outbound_click, filter events
- New `program_stats` table: daily denormalized metrics per program
- `POST /api/events` endpoint with IP hashing + type allowlist
- Client `track()` helper — fire-and-forget with `keepalive: true`
- Search tracking (debounced 800ms), filter tracking, program view + outbound click

## New files
- `supabase/migrations/002_events_tracking.sql`
- `src/app/api/events/route.ts`
- `src/lib/track.ts`
- `src/app/programs/[slug]/track-view.tsx`

## Test plan
- [ ] Visit a program page → check `events` table for `program_view`
- [ ] Search "AI" → check for `search` event with query in metadata
- [ ] Click "Join Program" → check for `outbound_click` event
- [ ] Apply category filter → check for `filter` event

🤖 Generated with [Claude Code](https://claude.com/claude-code)