### PR TITLE
feat: enrich events tracking with geo, device, sessions + all pages

### DIFF
--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -14,7 +14,16 @@ function hashIp(ip: string): string {
     .slice(0, 16);
 }
 
-const ALLOWED_TYPES = ["search", "program_view", "outbound_click", "filter"];
+const ALLOWED_TYPES = [
+  "page_view",
+  "search",
+  "program_view",
+  "outbound_click",
+  "filter",
+  "category_view",
+  "network_view",
+  "compare",
+];
 
 // POST /api/events — track an event
 export async function POST(req: NextRequest) {
@@ -34,6 +43,7 @@ export async function POST(req: NextRequest) {
 
   const ipHash = hashIp(ip);
   const referrer = req.headers.get("referer") ?? null;
+  const country = req.headers.get("x-vercel-ip-country") ?? null;
 
   await supabase.from("events").insert({
     type: body.type,
@@ -41,6 +51,10 @@ export async function POST(req: NextRequest) {
     metadata: body.metadata ?? {},
     ip_hash: ipHash,
     referrer,
+    country,
+    device: body.device ?? null,
+    path: body.path ?? null,
+    session_id: body.session_id ?? null,
   });
 
   return NextResponse.json({ ok: true });

--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import { ArrowLeft, ArrowRight, DollarSign, Clock, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProgramLogo } from "@/components/program-logo";
@@ -69,6 +70,7 @@ export default async function CategoryPage({
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <TrackPageView type="category_view" slug={slug} metadata={{ category }} />
       {/* Breadcrumb */}
       <Link
         href="/categories"

--- a/src/app/categories/page.tsx
+++ b/src/app/categories/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import { LayoutGrid } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProgramLogo } from "@/components/program-logo";
@@ -16,6 +17,7 @@ export default function CategoriesPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <TrackPageView />
       <div className="mb-8">
         <div className="flex items-center gap-2 mb-2">
           <LayoutGrid className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo, Suspense } from "react";
+import { useState, useMemo, Suspense, useEffect } from "react";
+import { track } from "@/lib/track";
 import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import {
@@ -133,6 +134,8 @@ const POPULAR_COMPARISONS = [
 function CompareContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
+
+  useEffect(() => { track("page_view"); }, []);
 
   const initialSlugs = (searchParams.get("p") ?? "")
     .split(",")

--- a/src/app/docs/page.tsx
+++ b/src/app/docs/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import { CopyButton } from "@/components/copy-button";
 
 export const metadata: Metadata = {
@@ -63,6 +64,7 @@ function SectionNav() {
 export default function DocsPage() {
   return (
     <div className="mx-auto max-w-3xl px-6 py-10">
+      <TrackPageView />
       <h1 className="text-2xl font-bold tracking-tight">Documentation</h1>
       <p className="text-sm text-muted-foreground mt-2 mb-8">
         How to use OpenAffiliate as a developer, agent builder, or contributor.

--- a/src/app/networks/[slug]/page.tsx
+++ b/src/app/networks/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import { ArrowLeft, ArrowRight, DollarSign, Clock, Users } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProgramLogo } from "@/components/program-logo";
@@ -57,6 +58,7 @@ export default async function NetworkPage({
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <TrackPageView type="network_view" slug={slug} metadata={{ network }} />
       <Link
         href="/networks"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors mb-8"

--- a/src/app/networks/page.tsx
+++ b/src/app/networks/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import { Network } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProgramLogo } from "@/components/program-logo";
@@ -16,6 +17,7 @@ export default function NetworksPage() {
 
   return (
     <div className="mx-auto max-w-6xl px-6 py-10">
+      <TrackPageView />
       <div className="mb-8">
         <div className="flex items-center gap-2 mb-2">
           <Network className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { TrackPageView } from "@/components/track-page-view";
 import {
   ArrowRight,
   Terminal,
@@ -197,6 +198,7 @@ export default function Home() {
 
   return (
     <div>
+      <TrackPageView />
       {/* Hero */}
       <section className="relative overflow-hidden">
         <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top,rgba(34,197,94,0.06),transparent_60%)]" />

--- a/src/app/rankings/page.tsx
+++ b/src/app/rankings/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useMemo, useCallback } from "react";
+import { useState, useMemo, useCallback, useEffect } from "react";
 import Link from "next/link";
 import { Trophy, Medal, Award, ArrowUpDown, ArrowUp, ArrowDown, CheckCircle2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { ProgramLogo } from "@/components/program-logo";
 import { FilterSelect } from "@/components/filter-select";
 import { VoteButton, useVoteCounts } from "@/components/vote-button";
+import { track } from "@/lib/track";
 import {
   programs,
   categories,
@@ -519,6 +520,8 @@ export default function RankingsPage() {
   const [selectedCategory, setSelectedCategory] = useState("");
   const [selectedType, setSelectedType] = useState("");
   const [verifiedOnly, setVerifiedOnly] = useState(false);
+
+  useEffect(() => { track("page_view"); }, []);
 
   const top3 = useMemo(() => {
     return [...programs]

--- a/src/app/submit/page.tsx
+++ b/src/app/submit/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { track } from "@/lib/track";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { categories as registryCategories } from "@/lib/programs";
 
 export default function SubmitPage() {
+  useEffect(() => { track("page_view"); }, []);
   const [form, setForm] = useState({
     name: "",
     slug: "",

--- a/src/components/track-page-view.tsx
+++ b/src/components/track-page-view.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useEffect } from "react";
+import { track } from "@/lib/track";
+
+export function TrackPageView({
+  type = "page_view",
+  slug,
+  metadata,
+}: {
+  type?: string;
+  slug?: string;
+  metadata?: Record<string, unknown>;
+}) {
+  useEffect(() => {
+    track(type, { slug, metadata });
+  }, [type, slug]);
+
+  return null;
+}

--- a/src/lib/track.ts
+++ b/src/lib/track.ts
@@ -1,8 +1,40 @@
+function getSessionId(): string {
+  if (typeof window === "undefined") return "";
+  let sid = sessionStorage.getItem("oa-sid");
+  if (!sid) {
+    sid = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    sessionStorage.setItem("oa-sid", sid);
+  }
+  return sid;
+}
+
+function getDevice(): string {
+  if (typeof window === "undefined") return "unknown";
+  return /Mobi|Android/i.test(navigator.userAgent) ? "mobile" : "desktop";
+}
+
+function getUtmParams(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const params = new URLSearchParams(window.location.search);
+  const utm: Record<string, string> = {};
+  for (const key of ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]) {
+    const val = params.get(key);
+    if (val) utm[key] = val;
+  }
+  return utm;
+}
+
 export function track(
   type: string,
   data?: { slug?: string; metadata?: Record<string, unknown> }
 ) {
   if (typeof window === "undefined") return;
+
+  const utm = getUtmParams();
+  const metadata = {
+    ...data?.metadata,
+    ...(Object.keys(utm).length > 0 ? { utm } : {}),
+  };
 
   fetch("/api/events", {
     method: "POST",
@@ -10,7 +42,10 @@ export function track(
     body: JSON.stringify({
       type,
       slug: data?.slug,
-      metadata: data?.metadata,
+      metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+      path: window.location.pathname,
+      session_id: getSessionId(),
+      device: getDevice(),
     }),
     keepalive: true,
   }).catch(() => {});

--- a/supabase/migrations/003_events_enrich.sql
+++ b/supabase/migrations/003_events_enrich.sql
@@ -1,0 +1,9 @@
+-- Enrich events with geo, device, path, session tracking
+ALTER TABLE events ADD COLUMN IF NOT EXISTS country text;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS device text;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS path text;
+ALTER TABLE events ADD COLUMN IF NOT EXISTS session_id text;
+
+CREATE INDEX IF NOT EXISTS idx_events_country ON events(country);
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id);
+CREATE INDEX IF NOT EXISTS idx_events_path ON events(path);


### PR DESCRIPTION
## Summary
- New columns on `events`: `country`, `device`, `path`, `session_id`
- `track()` now captures UTM params, device type (mobile/desktop), session ID (per browser session)
- `country` from Vercel's `x-vercel-ip-country` header
- Added `page_view` tracking to ALL pages: home, docs, categories, categories/[slug], networks, networks/[slug], rankings, submit, compare
- New event types: `page_view`, `category_view`, `network_view`, `compare`

## Queries now possible
```sql
-- Traffic by country
SELECT country, count(*) FROM events GROUP BY country ORDER BY count DESC;

-- Mobile vs desktop
SELECT device, count(*) FROM events GROUP BY device;

-- User journeys (session)
SELECT type, slug, path FROM events WHERE session_id = 'x' ORDER BY created_at;

-- UTM campaign performance
SELECT metadata->'utm'->>'utm_source', count(*) FROM events WHERE metadata->'utm' IS NOT NULL GROUP BY 1;
```

## Test plan
- [ ] Visit any page → check `events` table for `page_view` with country, device, path, session_id
- [ ] Visit from mobile → device = "mobile"
- [ ] Visit with ?utm_source=twitter → metadata contains utm object

🤖 Generated with [Claude Code](https://claude.com/claude-code)