### PR TITLE
fix: admin page auth redirect issue

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,4 +1,4 @@
-import { redirect } from "next/navigation";
+import { notFound } from "next/navigation";
 import { connection } from "next/server";
 import { createClient } from "@supabase/supabase-js";
 import { programs } from "@/lib/programs";
@@ -90,7 +90,7 @@ export default async function AdminPage({
   await connection();
   const { key } = await searchParams;
   if (key !== process.env.ADMIN_SECRET) {
-    redirect("/");
+    notFound();
   }
 
   const now = new Date();


### PR DESCRIPTION
## Summary
- `redirect("/")` was cached during prerender → always redirected
- Changed to `notFound()` which works correctly with Suspense boundary

## Test plan
- [ ] `/admin` without key → 404
- [ ] `/admin?key=CORRECT` → shows Command Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)