### PR TITLE
fix: unblock prod build — Satori display:flex in OG images

### DIFF
--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -43,9 +43,12 @@ export default async function Image() {
           </span>
         </div>
 
-        {/* Title */}
+        {/* Title — Satori requires display:flex when an element has >1 child
+            (here: text + colored <span> + text). flexWrap keeps it readable. */}
         <div
           style={{
+            display: "flex",
+            flexWrap: "wrap",
             fontSize: "56px",
             fontWeight: 800,
             color: "white",
@@ -53,8 +56,9 @@ export default async function Image() {
             marginBottom: "20px",
           }}
         >
-          The open registry of{" "}
-          <span style={{ color: "#34d399" }}>affiliate</span> programs.
+          <span>The open registry of&nbsp;</span>
+          <span style={{ color: "#34d399" }}>&nbsp;affiliate&nbsp;</span>
+          <span>&nbsp;programs.</span>
         </div>
 
         {/* Subtitle */}

--- a/src/app/rankings/opengraph-image.tsx
+++ b/src/app/rankings/opengraph-image.tsx
@@ -50,7 +50,7 @@ export default async function Image() {
           Affiliate Program Rankings
         </div>
         <div style={{ fontSize: "20px", color: "#94a3b8", marginBottom: "40px" }}>
-          Top programs ranked by commission — {programs.length} programs compared
+          {`Top programs ranked by commission — ${programs.length} programs compared`}
         </div>
 
         {/* Top 5 list */}


### PR DESCRIPTION
Second of the two pre-existing blockers keeping openaffiliate.dev stuck on a 36-day-old prod build (the first, `cacheComponents`, was fixed in #29).

Next/og (Satori) aborts the build when a block `<div>` has >1 child without `display:flex`:
- **`opengraph-image.tsx`** — title div (text + colored `<span>` + text) → `display:flex` + `flexWrap`, split into spans.
- **`rankings/opengraph-image.tsx`** — subtitle div (text + `{programs.length}` + text) → flattened to one template-literal child.

`programs/[slug]/opengraph-image.tsx` uses `<span>` (inline, fine) so it was unaffected.

**Verified:** full local prod build green — `✓ Generating static pages (874/874)`, all OG images render.

⚠️ This repo is synced from the `open-affiliate-pro` SSOT — mirror both fixes there or the next sync re-breaks the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)