### PR TITLE
fix: capture $pageview on every route so Web analytics works

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import { Nav } from "@/components/nav";
+import { PostHogPageView } from "@/components/posthog-pageview";
 import { ThemeProvider } from "@/components/theme-provider";
 import { ThemeToggle } from "@/components/theme-toggle";
 import "./globals.css";
@@ -165,6 +166,7 @@ export default function RootLayout({
       suppressHydrationWarning
     >
       <body className="min-h-full flex flex-col bg-background text-foreground">
+        <PostHogPageView />
         <ThemeProvider>
           <Nav />
           <main className="flex-1 dot-grid">{children}</main>

--- a/src/components/posthog-pageview.tsx
+++ b/src/components/posthog-pageview.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+// Captures a PostHog $pageview on the initial load and on every App Router
+// client navigation.
+//
+// We do NOT rely on posthog-js's built-in capture_pageview here. With the
+// project's `defaults: '2026-01-30'`, capture_pageview resolves to
+// 'history_change', which only fires on History API changes (SPA navigations)
+// and misses the first page load — so visitors who land and leave without
+// navigating produced zero $pageview events, leaving Web analytics empty.
+// instrumentation-client.ts therefore sets capture_pageview:false and this
+// effect is the single source of $pageview (fires on mount = initial load,
+// and whenever the pathname changes). posthog.capture fills $current_url,
+// $host, $pathname, $session_id, etc. automatically.
+export function PostHogPageView() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    if (!pathname) return;
+    try {
+      posthog.capture("$pageview");
+    } catch {
+      /* analytics must never break the UX */
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -17,12 +17,19 @@ if (key && typeof window !== "undefined") {
     posthog.init(key, {
       api_host: "/_ph",
       ui_host: "https://us.posthog.com",
-      // Modern defaults: history-change $pageview capture (works with the
-      // App Router), autocapture, and web vitals — no manual page tracking.
+      // Modern defaults give us autocapture, web vitals, and session replay.
       defaults: "2026-01-30",
       // No login on this site, so only spend person profiles on identified
       // users (we have none today). Keeps us comfortably on the free tier.
       person_profiles: "identified_only",
+      // defaults:'2026-01-30' resolves capture_pageview to 'history_change',
+      // which misses the initial page load — so landing-and-leaving visitors
+      // produced zero $pageview events and Web analytics stayed empty. Capture
+      // pageviews manually instead (see components/posthog-pageview.tsx), which
+      // fires on initial load + every route change. Disable the built-in one
+      // to avoid double-counting on client navigations.
+      capture_pageview: false,
+      capture_pageleave: true,
     });
   } catch {
     // Instrumentation must never break the app (Next.js 16 guidance).


### PR DESCRIPTION
**Problem:** PostHog Web analytics showed 0 visitors for openaffiliate.dev despite real daily traffic. Health: Ingestion "flowing normally" but `$pageview` = "No pageview events detected recently".

**Root cause:** `defaults:'2026-01-30'` resolves `capture_pageview` to `'history_change'` in posthog-js 1.376 — fires only on History API changes (SPA nav), **misses the initial page load**. Landing-and-leaving visitors → zero `$pageview`. Web analytics is built entirely on `$pageview`, hence 0. (Custom `track()` dual-write events still flowed → Ingestion green.)

**Fix:**
- New `components/posthog-pageview.tsx` — captures `$pageview` on mount (initial load) + every `usePathname` change, mounted in root layout.
- `instrumentation-client.ts` — `capture_pageview:false` (manual is now the single source; no double-count on nav) + `capture_pageleave:true`.

**Verified:** full prod build green (878/878 static pages). Will mirror to the open-affiliate-pro SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)