### PR TITLE
docs: preserve dual-audience onboarding plan, submit SDD, and mockups

### DIFF
--- a/docs/mockups/submit-final.html
+++ b/docs/mockups/submit-final.html
@@ -1,0 +1,1687 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>List Your Affiliate Program — OpenAffiliate</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+/* ── Design tokens (dark mode, exact match globals.css oklch values) ── */
+:root {
+  --bg:           #1a1a18;        /* oklch(0.13 0.005 75) */
+  --bg2:          #1f1f1d;        /* oklch(0.17 0.005 75) card */
+  --bg3:          #252523;        /* oklch(0.22 0.005 75) muted */
+  --fg:           #fafaf9;        /* oklch(0.985 0 0) */
+  --fg-muted:     #b5b4b0;        /* oklch(0.708 0 0) */
+  --fg-dim:       #6b6b67;
+  --border:       rgba(255,255,255,0.10);
+  --border-hi:    rgba(255,255,255,0.18);
+  --input-bg:     rgba(255,255,255,0.07);
+  --radius:       0.625rem;
+  --radius-lg:    0.875rem;
+  --radius-xl:    1.1rem;
+  --radius-2xl:   1.375rem;
+  --green:        oklch(0.7 0.15 160);
+  --green-dim:    oklch(0.55 0.14 160 / 20%);
+  --green-border: oklch(0.6 0.14 160 / 35%);
+  --green-hex:    #34d399;
+  --font: 'Geist', ui-sans-serif, system-ui, sans-serif;
+  --mono: 'Geist Mono', ui-monospace, monospace;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font);
+  line-height: 1.55;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Dot-grid bg */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle, rgba(255,255,255,0.035) 1px, transparent 1px);
+  background-size: 24px 24px;
+  pointer-events: none;
+  z-index: 0;
+}
+
+/* ── Nav ── */
+nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(26,26,24,0.88);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 24px;
+  height: 52px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+}
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+  color: var(--fg);
+  flex-shrink: 0;
+}
+.logo-mark {
+  width: 22px;
+  height: 22px;
+  border-radius: 5px;
+  background: #10b981;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.logo-mark svg { width: 13px; height: 13px; fill: white; }
+.logo-name { font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+.nav-links { display: flex; gap: 2px; list-style: none; }
+.nav-links a {
+  font-size: 13px;
+  color: var(--fg-muted);
+  text-decoration: none;
+  padding: 4px 10px;
+  border-radius: var(--radius);
+  transition: color 0.15s, background 0.15s;
+}
+.nav-links a:hover { color: var(--fg); background: rgba(255,255,255,0.06); }
+.nav-spacer { flex: 1; }
+.nav-cta {
+  font-size: 13px;
+  font-weight: 500;
+  font-family: var(--font);
+  color: var(--bg);
+  background: var(--fg);
+  border: none;
+  border-radius: var(--radius);
+  padding: 6px 14px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity 0.15s;
+  flex-shrink: 0;
+}
+.nav-cta:hover { opacity: 0.85; }
+
+/* ── Main layout ── */
+main {
+  position: relative;
+  z-index: 1;
+  flex: 1;
+}
+
+/* ── Page header band ── */
+.page-header {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 44px 24px 24px;
+}
+
+/* Dev escape hatch */
+.dev-escape {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--fg-dim);
+  text-decoration: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 10px;
+  margin-bottom: 28px;
+  transition: color 0.15s, border-color 0.15s;
+  font-family: var(--mono);
+}
+.dev-escape:hover { color: var(--fg-muted); border-color: var(--border-hi); }
+.dev-escape svg { width: 12px; height: 12px; opacity: 0.5; }
+
+/* Hero badge */
+.hero-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--green-dim);
+  border: 1px solid var(--green-border);
+  border-radius: 100px;
+  padding: 4px 12px 4px 8px;
+  font-size: 11.5px;
+  font-weight: 500;
+  color: oklch(0.78 0.13 160);
+  margin-bottom: 14px;
+}
+.hero-badge-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  flex-shrink: 0;
+  box-shadow: 0 0 6px oklch(0.7 0.15 160 / 60%);
+}
+
+h1 {
+  font-size: clamp(24px, 3.5vw, 34px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1.12;
+  margin-bottom: 10px;
+}
+.hero-sub {
+  font-size: 15px;
+  color: var(--fg-muted);
+  line-height: 1.5;
+  margin-bottom: 20px;
+  max-width: 520px;
+}
+
+/* Trust strip */
+.trust-strip {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0;
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.trust-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border-right: 1px solid var(--border);
+}
+.trust-item:first-child { padding-left: 0; }
+.trust-item:last-child { border-right: none; }
+.trust-icon { width: 13px; height: 13px; opacity: 0.55; }
+
+/* ── Split layout ── */
+.split-layout {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 24px 80px;
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: 28px;
+  align-items: start;
+}
+@media (max-width: 960px) {
+  .split-layout { grid-template-columns: 1fr; }
+  .preview-col { order: -1; }
+}
+@media (max-width: 640px) {
+  .preview-col { display: none; }
+  .preview-mobile-toggle-row { display: flex !important; }
+}
+
+/* ── Form column ── */
+.form-col { display: flex; flex-direction: column; gap: 0; }
+
+/* ── Card ── */
+.card {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-2xl);
+  padding: 24px 28px;
+  transition: border-color 0.2s;
+}
+
+/* ── URL hero input (v1 style) ── */
+.url-block-label {
+  font-size: 12.5px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.url-block-label .ai-spark {
+  width: 14px;
+  height: 14px;
+  color: var(--green);
+}
+.url-input-wrap {
+  display: flex;
+  align-items: center;
+  background: var(--input-bg);
+  border: 1.5px solid var(--border-hi);
+  border-radius: var(--radius-xl);
+  transition: border-color 0.2s, box-shadow 0.2s;
+  padding: 4px 4px 4px 0;
+}
+.url-input-wrap:focus-within {
+  border-color: oklch(0.7 0.15 160 / 50%);
+  box-shadow: 0 0 0 3px oklch(0.7 0.15 160 / 8%);
+}
+.url-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 15px;
+  padding: 12px 16px;
+  min-width: 0;
+}
+.url-input::placeholder { color: var(--fg-dim); }
+.autofill-btn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  background: var(--fg);
+  color: var(--bg);
+  font-family: var(--font);
+  font-size: 13.5px;
+  font-weight: 600;
+  border: none;
+  border-radius: calc(var(--radius-xl) - 6px);
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+  white-space: nowrap;
+}
+.autofill-btn:hover { opacity: 0.88; }
+.autofill-btn:active { transform: scale(0.98); }
+.autofill-btn svg { width: 15px; height: 15px; }
+.spark-icon { display: inline-block; transition: transform 0.3s; }
+.autofill-btn:hover .spark-icon { transform: rotate(15deg) scale(1.15); }
+
+/* Loading bar */
+.loading-bar-wrap {
+  height: 2px;
+  background: rgba(255,255,255,0.06);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-top: 14px;
+  display: none;
+}
+.loading-bar-wrap.active { display: block; }
+.loading-bar {
+  height: 100%;
+  background: linear-gradient(90deg, transparent, var(--green), transparent);
+  border-radius: 2px;
+  animation: shimmer 1.4s infinite;
+  width: 50%;
+}
+@keyframes shimmer {
+  0% { transform: translateX(-200%); }
+  100% { transform: translateX(400%); }
+}
+.loading-label {
+  margin-top: 10px;
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  display: none;
+  align-items: center;
+  gap: 6px;
+}
+.loading-label.active { display: flex; }
+.loading-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--green);
+  animation: ldot 1.2s infinite;
+}
+@keyframes ldot { 0%,100% { opacity: 0.3; } 50% { opacity: 1; } }
+
+/* ── Form panel (revealed after autofill) ── */
+#form-panel {
+  display: none;
+  animation: slideDown 0.35s cubic-bezier(0.16,1,0.3,1);
+}
+#form-panel.visible { display: block; }
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-10px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* Pre-fill notice */
+.pre-fill-notice {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--green-dim);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius-lg);
+  padding: 10px 14px;
+  font-size: 12.5px;
+  color: oklch(0.75 0.12 160);
+  margin: 18px 0 20px;
+}
+.pre-fill-notice svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+/* ── Section heading ── */
+.section-heading {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-dim);
+  margin-bottom: 14px;
+  margin-top: 24px;
+}
+.section-heading:first-of-type { margin-top: 4px; }
+
+/* ── Field ── */
+.field { margin-bottom: 14px; }
+.field-label {
+  display: block;
+  font-size: 12px;
+  color: var(--fg-muted);
+  margin-bottom: 6px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+.field-label .opt { color: var(--fg-dim); font-weight: 400; }
+.field-hint { font-size: 11px; color: var(--fg-dim); margin-top: 4px; line-height: 1.5; }
+
+.field input,
+.field select,
+.field textarea {
+  width: 100%;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 13.5px;
+  padding: 9px 12px;
+  outline: none;
+  transition: border-color 0.15s, box-shadow 0.15s;
+  appearance: none;
+}
+.field input:focus, .field select:focus, .field textarea:focus {
+  border-color: rgba(255,255,255,0.3);
+  box-shadow: 0 0 0 3px rgba(255,255,255,0.04);
+}
+.field input.filled, .field select.filled {
+  border-color: oklch(0.6 0.14 160 / 30%);
+  background: oklch(0.55 0.14 160 / 8%);
+}
+.field textarea { resize: none; line-height: 1.5; }
+.field select option { background: #1f1f1d; color: var(--fg); }
+
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+@media (max-width: 520px) { .field-row { grid-template-columns: 1fr; } }
+
+/* Divider */
+.field-divider {
+  border: none;
+  border-top: 1px solid var(--border);
+  margin: 20px 0;
+}
+
+/* ── Commission type pills ── */
+.pill-group {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+.pill {
+  font-family: var(--font);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.pill:hover { border-color: var(--border-hi); color: var(--fg); }
+.pill.selected {
+  background: var(--green-dim);
+  border-color: var(--green-border);
+  color: oklch(0.78 0.13 160);
+}
+
+/* Earn row: amount + commission type pills */
+.earn-amount-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+.earn-amount-row input {
+  width: 100px;
+  flex-shrink: 0;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 13.5px;
+  padding: 9px 12px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.earn-amount-row input.filled {
+  border-color: oklch(0.6 0.14 160 / 30%);
+  background: oklch(0.55 0.14 160 / 8%);
+}
+.earn-amount-row input:focus { border-color: rgba(255,255,255,0.3); }
+.earn-amount-row .earn-suffix {
+  font-size: 13px;
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+
+/* ── Cookie window pills ── */
+.cookie-pills {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 8px;
+}
+.cookie-pill {
+  font-family: var(--font);
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 14px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+.cookie-pill:hover { border-color: var(--border-hi); color: var(--fg); }
+.cookie-pill.selected {
+  background: rgba(255,255,255,0.07);
+  border-color: rgba(255,255,255,0.28);
+  color: var(--fg);
+}
+.cookie-custom-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+  display: none;
+}
+.cookie-custom-row.visible { display: flex; }
+.cookie-custom-row input {
+  width: 90px;
+  background: var(--input-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  color: var(--fg);
+  font-family: var(--font);
+  font-size: 13.5px;
+  padding: 8px 12px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+.cookie-custom-row input:focus { border-color: rgba(255,255,255,0.3); }
+.cookie-custom-row span { font-size: 13px; color: var(--fg-muted); }
+
+/* ── Advanced disclosure ── */
+.advanced-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  color: var(--fg-dim);
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  font-family: var(--font);
+  transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+.advanced-toggle:hover {
+  color: var(--fg-muted);
+  border-color: var(--border-hi);
+  background: rgba(255,255,255,0.04);
+}
+.advanced-toggle svg { width: 13px; height: 13px; transition: transform 0.2s; }
+.advanced-toggle.open svg { transform: rotate(90deg); }
+#advanced-fields { display: none; margin-top: 16px; animation: slideDown 0.25s cubic-bezier(0.16,1,0.3,1); }
+#advanced-fields.open { display: block; }
+
+/* ── Identity section ── */
+.identity-section {
+  background: rgba(255,255,255,0.025);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px 20px;
+  margin-top: 4px;
+  margin-bottom: 18px;
+}
+.identity-title { font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 3px; }
+.identity-sub { font-size: 12px; color: var(--fg-dim); margin-bottom: 14px; }
+.checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+.checkbox-row input[type="checkbox"] {
+  width: 15px;
+  height: 15px;
+  accent-color: var(--green);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+.checkbox-row label { font-size: 12.5px; color: var(--fg-muted); cursor: pointer; }
+.badge-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: oklch(0.62 0.16 230);
+  background: oklch(0.62 0.16 230 / 12%);
+  border: 1px solid oklch(0.62 0.16 230 / 25%);
+  border-radius: 4px;
+  padding: 1px 5px;
+  vertical-align: middle;
+  margin-left: 3px;
+}
+
+/* ── Submit button ── */
+.submit-btn {
+  width: 100%;
+  background: var(--fg);
+  color: var(--bg);
+  font-family: var(--font);
+  font-size: 15px;
+  font-weight: 700;
+  border: none;
+  border-radius: var(--radius-xl);
+  padding: 14px 24px;
+  cursor: pointer;
+  transition: opacity 0.15s, transform 0.1s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  letter-spacing: -0.01em;
+}
+.submit-btn:hover { opacity: 0.88; }
+.submit-btn:active { transform: scale(0.99); }
+.submit-note {
+  text-align: center;
+  font-size: 11.5px;
+  color: var(--fg-dim);
+  margin-top: 10px;
+  line-height: 1.5;
+}
+
+/* ── Preview column ── */
+.preview-col {
+  position: sticky;
+  top: 68px;
+}
+.preview-wrapper { display: flex; flex-direction: column; gap: 12px; }
+
+.preview-label-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-dim);
+}
+.preview-label-row::before, .preview-label-row::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.live-dot {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--green);
+  font-weight: 500;
+}
+.live-dot::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  animation: ldpulse 2s infinite;
+}
+@keyframes ldpulse {
+  0% { box-shadow: 0 0 0 0 oklch(0.7 0.15 160 / 40%); }
+  70% { box-shadow: 0 0 0 6px oklch(0.7 0.15 160 / 0%); }
+  100% { box-shadow: 0 0 0 0 oklch(0.7 0.15 160 / 0%); }
+}
+
+/* Program listing card (preview) */
+.program-card {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 18px;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+.program-card.has-content {
+  border-color: oklch(0.7 0.15 160 / 18%);
+  box-shadow: 0 0 20px oklch(0.7 0.15 160 / 5%);
+}
+.card-top { display: flex; align-items: flex-start; gap: 12px; margin-bottom: 11px; }
+.card-logo {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: var(--fg-dim);
+  flex-shrink: 0;
+  overflow: hidden;
+  transition: background 0.2s, color 0.2s;
+}
+.card-logo.filled {
+  background: linear-gradient(135deg, #0d2a1c 0%, #081811 100%);
+  color: var(--green);
+  border-color: oklch(0.7 0.15 160 / 18%);
+}
+.card-meta { flex: 1; min-width: 0; }
+.card-name {
+  font-size: 14px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  margin-bottom: 2px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: all 0.15s;
+}
+.card-name.empty { color: var(--fg-dim); font-weight: 400; font-style: italic; }
+.card-category { font-size: 11px; color: var(--fg-dim); }
+
+.card-badges { display: flex; gap: 5px; flex-wrap: wrap; margin-bottom: 10px; }
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  padding: 3px 8px;
+  border-radius: 100px;
+  line-height: 1;
+}
+.badge-commission { background: oklch(0.7 0.15 160 / 12%); color: oklch(0.78 0.13 160); border: 1px solid oklch(0.7 0.15 160 / 22%); }
+.badge-cookie { background: rgba(255,255,255,0.06); color: var(--fg-muted); border: 1px solid var(--border); }
+.badge-type { background: rgba(255,255,255,0.06); color: var(--fg-muted); border: 1px solid var(--border); }
+.badge-verified-stripe {
+  background: oklch(0.65 0.18 250 / 14%);
+  color: oklch(0.72 0.15 250);
+  border: 1px solid oklch(0.65 0.18 250 / 28%);
+}
+
+.card-description {
+  font-size: 12.5px;
+  color: var(--fg-muted);
+  line-height: 1.55;
+  margin-bottom: 13px;
+  min-height: 36px;
+}
+.card-description.empty { color: var(--fg-dim); font-style: italic; }
+.card-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.card-cta {
+  font-size: 12px;
+  font-weight: 600;
+  color: oklch(0.78 0.13 160);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.card-score {
+  font-size: 11px;
+  color: var(--fg-dim);
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Preview caption */
+.preview-caption {
+  font-size: 11.5px;
+  color: var(--fg-dim);
+  line-height: 1.55;
+  padding: 12px 14px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+}
+.preview-caption strong { color: var(--fg-muted); }
+.preview-caption ul { list-style: none; margin-top: 7px; display: flex; flex-direction: column; gap: 4px; }
+.preview-caption ul li { display: flex; gap: 6px; }
+.preview-caption ul li::before { content: '↳'; color: oklch(0.78 0.13 160); flex-shrink: 0; font-size: 11px; margin-top: 1px; }
+
+/* Mobile preview toggle */
+.preview-mobile-toggle-row {
+  display: none;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+.preview-mobile-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: var(--font);
+  color: oklch(0.78 0.13 160);
+  background: var(--green-dim);
+  border: 1px solid var(--green-border);
+  border-radius: var(--radius);
+  padding: 6px 12px;
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+.preview-mobile-btn:hover { opacity: 0.8; }
+.mobile-preview-card {
+  display: none;
+  margin-bottom: 16px;
+  animation: slideDown 0.3s cubic-bezier(0.16,1,0.3,1);
+}
+.mobile-preview-card.visible { display: block; }
+
+/* ── Success state ── */
+#success-panel { display: none; }
+#success-panel.visible { display: block; animation: slideDown 0.4s cubic-bezier(0.16,1,0.3,1); }
+
+.success-wrap {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  text-align: center;
+}
+.success-icon-wrap {
+  width: 68px;
+  height: 68px;
+  border-radius: 50%;
+  background: var(--green-dim);
+  border: 1px solid var(--green-border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 auto 20px;
+  animation: pulse-success 2.5s ease infinite;
+}
+@keyframes pulse-success {
+  0%,100% { box-shadow: 0 0 0 0 oklch(0.7 0.15 160 / 0%); }
+  50% { box-shadow: 0 0 0 10px oklch(0.7 0.15 160 / 0%); }
+}
+.success-h { font-size: 26px; font-weight: 700; letter-spacing: -0.03em; margin-bottom: 10px; }
+.success-sub {
+  font-size: 14px;
+  color: var(--fg-muted);
+  line-height: 1.55;
+  max-width: 400px;
+  margin: 0 auto 28px;
+}
+.success-sub strong { color: var(--fg); }
+
+.success-email-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg3);
+  border: 1px solid var(--border);
+  border-radius: 40px;
+  padding: 8px 16px;
+  font-size: 13px;
+  color: var(--fg-muted);
+  margin-bottom: 32px;
+}
+.success-email-badge svg { color: oklch(0.78 0.13 160); }
+
+.what-next {
+  background: var(--bg2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-xl);
+  padding: 22px 24px;
+  text-align: left;
+  margin-bottom: 24px;
+}
+.what-next-title {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--fg-dim);
+  margin-bottom: 16px;
+}
+.next-steps { list-style: none; }
+.next-steps li {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  padding: 12px 0;
+  border-bottom: 1px solid var(--border);
+}
+.next-steps li:last-child { border-bottom: none; padding-bottom: 0; }
+.step-num {
+  flex-shrink: 0;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: rgba(255,255,255,0.06);
+  border: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--fg-muted);
+}
+.step-num.done {
+  background: var(--green-dim);
+  border-color: var(--green-border);
+  color: oklch(0.78 0.13 160);
+}
+.step-body { flex: 1; }
+.step-title { font-size: 13.5px; font-weight: 600; margin-bottom: 3px; color: var(--fg); }
+.step-desc { font-size: 12.5px; color: var(--fg-muted); line-height: 1.5; }
+
+/* Stripe verify badge (inline) */
+.stripe-badge-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  background: oklch(0.65 0.18 250 / 12%);
+  color: oklch(0.72 0.15 250);
+  border: 1px solid oklch(0.65 0.18 250 / 25%);
+  border-radius: 100px;
+  padding: 2px 8px;
+  vertical-align: middle;
+  margin-left: 3px;
+}
+.stripe-badge-inline svg { width: 9px; height: 9px; }
+
+.success-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.btn-outline {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font);
+  font-size: 13px;
+  font-weight: 500;
+  padding: 9px 18px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--bg3);
+  color: var(--fg-muted);
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 0.15s;
+}
+.btn-outline:hover { color: var(--fg); border-color: var(--border-hi); }
+
+/* ── Footer ── */
+footer {
+  position: relative;
+  z-index: 1;
+  border-top: 1px solid var(--border);
+  padding: 24px;
+  text-align: center;
+}
+footer .footer-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+.footer-left { font-size: 12px; color: var(--fg-dim); display: flex; align-items: center; gap: 8px; }
+.footer-links { display: flex; gap: 16px; flex-wrap: wrap; }
+footer a { font-size: 12px; color: var(--fg-dim); text-decoration: none; transition: color 0.15s; }
+footer a:hover { color: var(--fg-muted); }
+
+/* ── Demo controls ── */
+.demo-controls {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 100;
+  display: flex;
+  gap: 8px;
+  flex-direction: column;
+  align-items: flex-end;
+}
+.demo-controls-label { font-size: 10px; font-family: var(--mono); color: var(--fg-dim); text-align: right; }
+.demo-btns { display: flex; gap: 6px; }
+.demo-btn {
+  font-size: 11px;
+  font-family: var(--mono);
+  background: var(--bg3);
+  color: var(--fg-muted);
+  border: 1px solid var(--border-hi);
+  border-radius: var(--radius);
+  padding: 6px 11px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.demo-btn:hover { background: rgba(255,255,255,0.08); color: var(--fg); }
+
+/* ── Responsive ── */
+@media (max-width: 480px) {
+  .page-header { padding: 28px 16px 16px; }
+  .split-layout { padding: 0 16px 64px; }
+  .card { padding: 18px 20px; }
+  h1 { font-size: 24px; }
+  .trust-item { font-size: 11px; padding: 2px 8px; }
+  .autofill-btn { font-size: 12.5px; padding: 9px 14px; }
+}
+</style>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo">
+      <div class="logo-mark">
+        <svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="3" fill="white"/><path d="M8 2 L8 5 M8 11 L8 14 M2 8 L5 8 M11 8 L14 8" stroke="white" stroke-width="1.5" stroke-linecap="round"/></svg>
+      </div>
+      <span class="logo-name">OpenAffiliate</span>
+    </a>
+    <ul class="nav-links">
+      <li><a href="/programs">Programs</a></li>
+      <li><a href="/categories">Categories</a></li>
+      <li><a href="/rankings">Rankings</a></li>
+    </ul>
+    <div class="nav-spacer"></div>
+    <a href="/programs" class="nav-cta">Browse Programs</a>
+  </div>
+</nav>
+
+<!-- Main -->
+<main>
+
+  <!-- ── FORM STATE ── -->
+  <div id="form-state">
+
+    <!-- Page header -->
+    <div class="page-header">
+
+      <!-- Dev escape -->
+      <a href="https://github.com/Affitor/open-affiliate" class="dev-escape">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.11.82-.26.82-.58v-2.16c-3.34.72-4.04-1.61-4.04-1.61-.54-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.73.08-.73 1.2.09 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.49 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.23-3.22-.12-.3-.53-1.52.12-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.14 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
+        Developer? List via GitHub
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+      </a>
+
+      <div class="hero-badge">
+        <span class="hero-badge-dot"></span>
+        750+ programs listed · Free forever
+      </div>
+
+      <h1>List your affiliate program.</h1>
+      <p class="hero-sub">Paste your affiliates page URL. We'll read it and fill in the details for you — takes about 30 seconds.</p>
+
+      <!-- Trust strip -->
+      <div class="trust-strip">
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Free forever
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          750+ programs
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+          Discovered by AI agents
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="5" width="20" height="14" rx="2"/><line x1="2" y1="10" x2="22" y2="10"/></svg>
+          Verified-by-Stripe option
+        </span>
+      </div>
+
+    </div><!-- /page-header -->
+
+    <!-- Split layout -->
+    <div class="split-layout">
+
+      <!-- ── Form column ── -->
+      <div class="form-col">
+
+        <!-- Mobile preview toggle (only shows <640px) -->
+        <div class="preview-mobile-toggle-row">
+          <button class="preview-mobile-btn" onclick="toggleMobilePreview()">
+            <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="3" width="20" height="14" rx="2"/><line x1="8" y1="21" x2="16" y2="21"/><line x1="12" y1="17" x2="12" y2="21"/></svg>
+            Preview listing
+          </button>
+          <span style="font-size:11px;color:var(--fg-dim)">See how it looks in the directory</span>
+        </div>
+
+        <!-- Mobile preview (hidden by default) -->
+        <div class="mobile-preview-card" id="mobile-preview-card">
+          <div id="mobile-preview-card-inner"></div>
+        </div>
+
+        <!-- URL hero card -->
+        <div class="card" style="margin-bottom: 1px; border-bottom-left-radius: 6px; border-bottom-right-radius: 6px;">
+
+          <div class="url-block-label">
+            <svg class="ai-spark" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+            Your affiliate program page URL
+          </div>
+
+          <div class="url-input-wrap">
+            <input
+              id="url-input"
+              class="url-input"
+              type="url"
+              placeholder="e.g. yourproduct.com/affiliates"
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="Affiliate program URL"
+            >
+            <button class="autofill-btn" onclick="doAutofill()" aria-label="Auto-fill with AI">
+              <span class="spark-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+              </span>
+              Auto-fill with AI
+            </button>
+          </div>
+
+          <div class="loading-bar-wrap" id="loading-bar-wrap"><div class="loading-bar"></div></div>
+          <div class="loading-label" id="loading-label"><span class="loading-dot"></span> Reading your affiliates page...</div>
+
+          <!-- ── Form panel (slides in after autofill) ── -->
+          <div id="form-panel">
+
+            <div class="pre-fill-notice">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="oklch(0.7 0.15 160)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+              We pre-filled what we found. Review and adjust anything that looks off.
+            </div>
+
+            <!-- Basics -->
+            <div class="field">
+              <label class="field-label">Program name</label>
+              <input type="text" class="filled" value="Notion" id="f-name" oninput="updatePreview()" aria-label="Program name">
+            </div>
+
+            <div class="field-row">
+              <div class="field">
+                <label class="field-label">Your website</label>
+                <input type="url" class="filled" value="notion.so" id="f-url" aria-label="Website">
+              </div>
+              <div class="field">
+                <label class="field-label">Category</label>
+                <select class="filled" id="f-category" onchange="updatePreview()" aria-label="Category">
+                  <option>Productivity</option>
+                  <option>Developer Tools</option>
+                  <option>Email Marketing</option>
+                  <option>CRM &amp; Sales</option>
+                  <option>Design</option>
+                  <option>Analytics</option>
+                  <option>E-commerce</option>
+                  <option>Finance</option>
+                  <option>Security</option>
+                  <option>AI &amp; Machine Learning</option>
+                  <option>Project Management</option>
+                  <option>Communication</option>
+                  <option>HR &amp; Recruiting</option>
+                  <option>Data &amp; BI</option>
+                  <option>Video &amp; Media</option>
+                  <option>Other</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field-label">One-line pitch <span class="opt">(shown on your listing)</span></label>
+              <input type="text" class="filled" value="The connected workspace for notes, docs, and projects." id="f-pitch" maxlength="120" oninput="updatePreview(); updatePitchCount();" aria-label="One-line pitch">
+              <p class="field-hint" id="pitch-count">56 / 120 characters</p>
+            </div>
+
+            <!-- Commission -->
+            <div class="section-heading">What do affiliates earn?</div>
+
+            <div class="field">
+              <label class="field-label">Commission type</label>
+              <div class="pill-group" role="group" aria-label="Commission type">
+                <button class="pill selected" onclick="selectCommType(this, 'recurring')" data-type="recurring" aria-pressed="true">% of every renewal</button>
+                <button class="pill" onclick="selectCommType(this, 'onetime')" data-type="onetime" aria-pressed="false">% of first sale</button>
+                <button class="pill" onclick="selectCommType(this, 'flat')" data-type="flat" aria-pressed="false">Fixed $ per sale</button>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field-label" id="earn-label">Commission rate</label>
+              <div class="earn-amount-row">
+                <input type="text" class="filled" value="50" id="f-earn-amount" placeholder="e.g. 25" oninput="updatePreview()" aria-label="Commission amount">
+                <span class="earn-suffix" id="earn-suffix">% per renewal</span>
+              </div>
+              <p class="field-hint">e.g. "25% recurring" or "$50 per signup"</p>
+            </div>
+
+            <!-- Cookie window pills -->
+            <div class="field">
+              <label class="field-label">How long is a referral tracked?</label>
+              <div class="cookie-pills" role="group" aria-label="Cookie window">
+                <button class="cookie-pill" onclick="selectCookie(this, '7')" aria-pressed="false">7 days</button>
+                <button class="cookie-pill" onclick="selectCookie(this, '30')" aria-pressed="false">30 days</button>
+                <button class="cookie-pill" onclick="selectCookie(this, '60')" aria-pressed="false">60 days</button>
+                <button class="cookie-pill selected" onclick="selectCookie(this, '90')" aria-pressed="true">90 days</button>
+                <button class="cookie-pill" onclick="selectCookie(this, 'lifetime')" aria-pressed="false">Lifetime</button>
+                <button class="cookie-pill" onclick="selectCookie(this, 'custom')" aria-pressed="false">Custom</button>
+              </div>
+              <div class="cookie-custom-row" id="cookie-custom-row">
+                <input type="number" id="f-cookie-custom" value="" min="1" max="730" placeholder="e.g. 45" oninput="updatePreview()" aria-label="Custom cookie days">
+                <span>days</span>
+              </div>
+              <input type="hidden" id="f-cookie" value="90">
+              <p class="field-hint">After someone clicks your link, this is how long you get credit for their signup.</p>
+            </div>
+
+            <hr class="field-divider">
+
+            <!-- Optional details -->
+            <button class="advanced-toggle" id="advanced-toggle-btn" onclick="toggleAdvanced()" aria-expanded="false" aria-controls="advanced-fields">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+              Add more details <span style="color:var(--fg-dim);font-size:11px;">(optional)</span>
+            </button>
+            <div id="advanced-fields">
+              <div class="field-row" style="margin-top:0">
+                <div class="field">
+                  <label class="field-label">Minimum payout</label>
+                  <input type="text" value="$50" id="f-min-payout" placeholder="e.g. $50" aria-label="Minimum payout">
+                  <p class="field-hint">Minimum balance before affiliates get paid.</p>
+                </div>
+                <div class="field">
+                  <label class="field-label">Paid out</label>
+                  <select id="f-payout-freq" aria-label="Payout frequency">
+                    <option>Monthly</option>
+                    <option>Every 2 weeks</option>
+                    <option>Net 30</option>
+                    <option>Net 60</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label class="field-label">Affiliate signup link <span class="opt">(where they apply)</span></label>
+                <input type="url" value="notion.so/affiliates" id="f-signup-url" placeholder="yourproduct.com/affiliates" aria-label="Affiliate signup link">
+              </div>
+              <div class="field">
+                <label class="field-label">Any restrictions or requirements? <span class="opt">(optional)</span></label>
+                <textarea rows="2" id="f-restrictions" placeholder="e.g. US &amp; EU only · Must have 1k+ followers · No paid search" aria-label="Restrictions"></textarea>
+              </div>
+            </div>
+
+            <!-- Identity / email -->
+            <div class="identity-section">
+              <div class="identity-title">Where should we send your listing link?</div>
+              <div class="identity-sub">We'll email you a magic link to edit or claim your listing later. No password needed.</div>
+              <div class="field" style="margin-bottom: 0;">
+                <input type="email" id="f-email" placeholder="you@yourcompany.com" style="font-size:14px;" aria-label="Email address">
+              </div>
+              <div class="checkbox-row">
+                <input type="checkbox" id="works-here" checked aria-label="I work at this company">
+                <label for="works-here">
+                  I work at this company
+                  <span class="badge-inline">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                    Verified badge later
+                  </span>
+                </label>
+              </div>
+            </div>
+
+            <!-- Submit -->
+            <button class="submit-btn" onclick="doSubmit()">
+              <svg width="17" height="17" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4 20-7z"/><path d="M22 2 11 13"/></svg>
+              Submit for review
+            </button>
+            <p class="submit-note">Free forever. Usually live in minutes. We review every submission.</p>
+
+          </div><!-- /form-panel -->
+
+        </div><!-- /card -->
+
+      </div><!-- /form-col -->
+
+      <!-- ── Preview column ── -->
+      <div class="preview-col" aria-label="Live listing preview">
+        <div class="preview-wrapper">
+
+          <div class="preview-label-row">
+            <span class="live-dot">Live preview</span>
+          </div>
+
+          <!-- Program card preview -->
+          <div class="program-card" id="preview-card">
+            <div class="card-top">
+              <div class="card-logo" id="prev-logo">?</div>
+              <div class="card-meta">
+                <div class="card-name" id="prev-name">Notion</div>
+                <div class="card-category" id="prev-category">Productivity · openaffiliate.dev</div>
+              </div>
+            </div>
+            <div class="card-badges">
+              <span class="badge badge-commission" id="prev-commission">50% commission</span>
+              <span class="badge badge-cookie" id="prev-cookie">90d cookie</span>
+              <span class="badge badge-type" id="prev-type">Recurring</span>
+            </div>
+            <div class="card-description" id="prev-description">The connected workspace for notes, docs, and projects.</div>
+            <div class="card-footer">
+              <span class="card-cta">
+                Apply to program
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              </span>
+              <span class="card-score">
+                <svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                Score pending
+              </span>
+            </div>
+          </div>
+
+          <!-- Caption -->
+          <div class="preview-caption">
+            <strong>This is what affiliates and AI agents will see</strong> in the directory.
+            <ul>
+              <li>Affiliates browse by commission and category</li>
+              <li>AI agents use this to recommend your product to buyers</li>
+              <li>Verified programs rank higher and convert more</li>
+            </ul>
+          </div>
+
+        </div>
+      </div><!-- /preview-col -->
+
+    </div><!-- /split-layout -->
+
+  </div><!-- /form-state -->
+
+  <!-- ── SUCCESS STATE ── -->
+  <div id="success-panel">
+    <div class="success-wrap">
+
+      <div class="success-icon-wrap">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="oklch(0.7 0.15 160)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="30" height="30"><path d="M20 6 9 17l-5-5"/></svg>
+      </div>
+
+      <div class="success-h">You're in the queue.</div>
+      <p class="success-sub">
+        <strong id="success-name">Notion</strong> has been submitted. Check your email — we'll send you a link to track your listing and make edits.
+      </p>
+
+      <div class="success-email-badge">
+        <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        Check your email for an edit link
+      </div>
+
+      <div class="what-next">
+        <div class="what-next-title">What happens next</div>
+        <ul class="next-steps">
+          <li>
+            <span class="step-num done">
+              <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+            </span>
+            <div class="step-body">
+              <div class="step-title">Submitted</div>
+              <div class="step-desc">Your program is in the review queue. Done!</div>
+            </div>
+          </li>
+          <li>
+            <span class="step-num">2</span>
+            <div class="step-body">
+              <div class="step-title">Quick review</div>
+              <div class="step-desc">Our bot checks the basics — commission &ge; 1%, working URL, no duplicates. Usually under a minute.</div>
+            </div>
+          </li>
+          <li>
+            <span class="step-num">3</span>
+            <div class="step-body">
+              <div class="step-title">Goes live</div>
+              <div class="step-desc">Your program appears in the OpenAffiliate directory and gets indexed by AI agents and discovery tools.</div>
+            </div>
+          </li>
+          <li>
+            <span class="step-num">4</span>
+            <div class="step-body">
+              <div class="step-title">Claim your listing &amp; get
+                <span class="stripe-badge-inline">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                  Verified by Stripe
+                </span>
+              </div>
+              <div class="step-desc">Click the link in your email, then connect your Stripe account to confirm real payouts. Verified programs rank higher and convert more affiliates — it's the trust signal that matters.</div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="success-actions">
+        <a href="/programs" class="btn-outline">
+          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+          Browse programs
+        </a>
+        <button class="btn-outline" onclick="resetAll()">
+          <svg xmlns="http://www.w3.org/2000/svg" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Submit another program
+        </button>
+      </div>
+
+    </div>
+  </div><!-- /success-panel -->
+
+</main>
+
+<!-- Footer -->
+<footer>
+  <div class="footer-inner">
+    <div class="footer-left">
+      <div class="logo-mark" style="width:18px;height:18px;border-radius:4px;">
+        <svg viewBox="0 0 16 16"><circle cx="8" cy="8" r="2.5" fill="white"/><path d="M8 2.5 L8 5 M8 11 L8 13.5 M2.5 8 L5 8 M11 8 L13.5 8" stroke="white" stroke-width="1.5" stroke-linecap="round"/></svg>
+      </div>
+      OpenAffiliate — open source, community-driven
+    </div>
+    <div class="footer-links">
+      <a href="/programs">Programs</a>
+      <a href="/docs">Docs</a>
+      <a href="https://github.com/Affitor/open-affiliate">GitHub</a>
+      <a href="/feedback">Feedback</a>
+      <a href="https://github.com/Affitor/open-affiliate" style="font-family:var(--mono);font-size:11px;color:var(--fg-dim)">Developer? List via GitHub →</a>
+    </div>
+  </div>
+</footer>
+
+<!-- Demo controls -->
+<div class="demo-controls">
+  <div class="demo-controls-label">mockup demo controls</div>
+  <div class="demo-btns">
+    <button class="demo-btn" onclick="demoShowForm()">show form</button>
+    <button class="demo-btn" onclick="demoShowSuccess()">show success</button>
+    <button class="demo-btn" onclick="resetAll()">reset</button>
+  </div>
+</div>
+
+<script>
+/* ── State ── */
+var commType = 'recurring';
+var cookieValue = '90';
+var mobilePreviewOpen = false;
+
+/* ── Enter on URL input ── */
+document.getElementById('url-input').addEventListener('keydown', function(e) {
+  if (e.key === 'Enter') doAutofill();
+});
+
+/* ── Pitch count ── */
+function updatePitchCount() {
+  var v = document.getElementById('f-pitch').value.length;
+  document.getElementById('pitch-count').textContent = v + ' / 120 characters';
+}
+
+/* ── Auto-fill simulation ── */
+function doAutofill() {
+  var url = document.getElementById('url-input').value.trim();
+  if (!url) {
+    var inp = document.getElementById('url-input');
+    inp.focus();
+    inp.parentElement.style.borderColor = 'oklch(0.7 0.2 30 / 60%)';
+    setTimeout(function() { inp.parentElement.style.borderColor = ''; }, 1500);
+    return;
+  }
+  document.getElementById('loading-bar-wrap').classList.add('active');
+  document.getElementById('loading-label').classList.add('active');
+  var btn = document.querySelector('.autofill-btn');
+  btn.disabled = true;
+  btn.style.opacity = '0.5';
+
+  setTimeout(function() {
+    document.getElementById('loading-bar-wrap').classList.remove('active');
+    document.getElementById('loading-label').classList.remove('active');
+    btn.disabled = false;
+    btn.style.opacity = '';
+    demoShowForm();
+  }, 1800);
+}
+
+function demoShowForm() {
+  document.getElementById('form-panel').classList.add('visible');
+  updatePreview();
+  setTimeout(function() {
+    document.getElementById('form-panel').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }, 60);
+}
+
+/* ── Commission type pills ── */
+function selectCommType(el, type) {
+  commType = type;
+  document.querySelectorAll('.pill-group .pill').forEach(function(p) {
+    p.classList.remove('selected');
+    p.setAttribute('aria-pressed', 'false');
+  });
+  el.classList.add('selected');
+  el.setAttribute('aria-pressed', 'true');
+
+  var suffix = document.getElementById('earn-suffix');
+  if (type === 'recurring') suffix.textContent = '% per renewal';
+  else if (type === 'onetime') suffix.textContent = '% of first sale';
+  else suffix.textContent = 'USD per sale';
+
+  updatePreview();
+}
+
+/* ── Cookie window pills ── */
+function selectCookie(el, val) {
+  cookieValue = val;
+  document.querySelectorAll('.cookie-pill').forEach(function(p) {
+    p.classList.remove('selected');
+    p.setAttribute('aria-pressed', 'false');
+  });
+  el.classList.add('selected');
+  el.setAttribute('aria-pressed', 'true');
+
+  var customRow = document.getElementById('cookie-custom-row');
+  if (val === 'custom') {
+    customRow.classList.add('visible');
+    document.getElementById('f-cookie').value = document.getElementById('f-cookie-custom').value || '';
+  } else {
+    customRow.classList.remove('visible');
+    document.getElementById('f-cookie').value = val;
+  }
+  updatePreview();
+}
+
+document.getElementById('f-cookie-custom').addEventListener('input', function() {
+  document.getElementById('f-cookie').value = this.value;
+  updatePreview();
+});
+
+/* ── Advanced toggle ── */
+function toggleAdvanced() {
+  var btn = document.getElementById('advanced-toggle-btn');
+  var panel = document.getElementById('advanced-fields');
+  var open = panel.classList.toggle('open');
+  btn.classList.toggle('open', open);
+  btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+}
+
+/* ── Live preview update ── */
+function updatePreview() {
+  var name = document.getElementById('f-name').value.trim();
+  var category = document.getElementById('f-category').value;
+  var pitch = document.getElementById('f-pitch').value.trim();
+  var earnAmt = document.getElementById('f-earn-amount').value.trim();
+  var cookie = document.getElementById('f-cookie').value;
+
+  /* Name */
+  var nameEl = document.getElementById('prev-name');
+  nameEl.textContent = name || 'Your program name';
+  nameEl.classList.toggle('empty', !name);
+
+  /* Logo initials */
+  var logoEl = document.getElementById('prev-logo');
+  if (name) {
+    var words = name.trim().split(/\s+/);
+    var initials = words.length >= 2
+      ? (words[0][0] + words[1][0]).toUpperCase()
+      : name.slice(0, 2).toUpperCase();
+    logoEl.textContent = initials;
+    logoEl.classList.add('filled');
+  } else {
+    logoEl.textContent = '?';
+    logoEl.classList.remove('filled');
+  }
+
+  /* Category */
+  document.getElementById('prev-category').textContent = (category || 'Category') + ' · openaffiliate.dev';
+
+  /* Description */
+  var descEl = document.getElementById('prev-description');
+  descEl.textContent = pitch || 'Your one-line pitch will appear here — what makes affiliates want to promote you?';
+  descEl.classList.toggle('empty', !pitch);
+
+  /* Commission badge */
+  var commBadge = document.getElementById('prev-commission');
+  var typeLabel = commType === 'recurring' ? 'Recurring' : commType === 'onetime' ? 'One-time' : 'Flat fee';
+  if (earnAmt) {
+    var prefix = commType === 'flat' ? '$' : '';
+    var suffix = commType === 'flat' ? '' : '%';
+    commBadge.textContent = prefix + earnAmt + suffix + ' commission';
+  } else {
+    commBadge.textContent = '— commission';
+  }
+  document.getElementById('prev-type').textContent = typeLabel;
+
+  /* Cookie badge */
+  var cookieBadge = document.getElementById('prev-cookie');
+  var cookieMap = { '7': '7d cookie', '30': '30d cookie', '60': '60d cookie', '90': '90d cookie', 'lifetime': 'Lifetime cookie' };
+  if (cookie === 'lifetime') cookieBadge.textContent = 'Lifetime cookie';
+  else if (cookie && cookieMap[cookie]) cookieBadge.textContent = cookieMap[cookie];
+  else if (cookie) cookieBadge.textContent = cookie + 'd cookie';
+  else cookieBadge.textContent = '— cookie';
+
+  /* Card glow */
+  document.getElementById('preview-card').classList.toggle('has-content', !!(name || pitch || earnAmt));
+
+  /* Update success state name */
+  document.getElementById('success-name').textContent = name || 'Your program';
+
+  /* Sync mobile preview if open */
+  if (mobilePreviewOpen) renderMobilePreview();
+}
+
+/* ── Mobile preview ── */
+function toggleMobilePreview() {
+  mobilePreviewOpen = !mobilePreviewOpen;
+  var el = document.getElementById('mobile-preview-card');
+  if (mobilePreviewOpen) {
+    renderMobilePreview();
+    el.classList.add('visible');
+  } else {
+    el.classList.remove('visible');
+  }
+}
+
+function renderMobilePreview() {
+  var inner = document.getElementById('mobile-preview-card-inner');
+  inner.innerHTML = document.getElementById('preview-card').parentElement.innerHTML;
+  // Clone just the card
+  inner.innerHTML = '';
+  var clone = document.getElementById('preview-card').cloneNode(true);
+  clone.id = '';
+  inner.appendChild(clone);
+}
+
+/* ── Submit ── */
+function doSubmit() {
+  var email = document.getElementById('f-email').value.trim();
+  if (!email || !email.includes('@')) {
+    var inp = document.getElementById('f-email');
+    inp.focus();
+    inp.style.borderColor = 'oklch(0.7 0.2 30 / 60%)';
+    setTimeout(function() { inp.style.borderColor = ''; }, 1500);
+    return;
+  }
+  demoShowSuccess();
+}
+
+function demoShowSuccess() {
+  updatePreview();
+  document.getElementById('form-state').style.display = 'none';
+  var sp = document.getElementById('success-panel');
+  sp.classList.add('visible');
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+/* ── Reset ── */
+function resetAll() {
+  document.getElementById('form-state').style.display = '';
+  var sp = document.getElementById('success-panel');
+  sp.classList.remove('visible');
+  document.getElementById('form-panel').classList.remove('visible');
+  document.getElementById('advanced-fields').classList.remove('open');
+  document.getElementById('advanced-toggle-btn').classList.remove('open');
+  document.getElementById('advanced-toggle-btn').setAttribute('aria-expanded', 'false');
+  document.getElementById('loading-bar-wrap').classList.remove('active');
+  document.getElementById('loading-label').classList.remove('active');
+  document.querySelector('.autofill-btn').disabled = false;
+  document.querySelector('.autofill-btn').style.opacity = '';
+  document.getElementById('url-input').value = '';
+  mobilePreviewOpen = false;
+  document.getElementById('mobile-preview-card').classList.remove('visible');
+  window.scrollTo({ top: 0, behavior: 'smooth' });
+}
+
+/* ── Init preview with demo data ── */
+updatePreview();
+</script>
+
+</body>
+</html>

--- a/docs/mockups/submit-v1-ai-first-single.html
+++ b/docs/mockups/submit-v1-ai-first-single.html
@@ -1,0 +1,1124 @@
+<!doctype html>
+<html lang="en" class="dark">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>List Your Affiliate Program — OpenAffiliate</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  /* ── Design tokens (dark, matching openaffiliate.dev globals.css) ── */
+  :root {
+    --bg:         #1a1a18;        /* oklch(0.13 0.005 75) */
+    --bg2:        #1f1f1d;        /* card */
+    --bg3:        #252523;        /* secondary / muted */
+    --fg:         #fafaf9;        /* oklch(0.985 0 0) */
+    --fg-muted:   #b5b4b0;        /* oklch(0.708 0 0) */
+    --fg-dim:     #6b6b67;
+    --border:     rgba(255,255,255,0.10);
+    --border-hi:  rgba(255,255,255,0.18);
+    --input-bg:   rgba(255,255,255,0.07);
+    --radius:     0.625rem;
+    --radius-lg:  0.875rem;
+    --radius-xl:  1.1rem;
+    --radius-2xl: 1.375rem;
+    --green:      oklch(0.7 0.15 160);       /* accent emerald */
+    --green-dim:  oklch(0.55 0.14 160 / 20%);
+    --green-border: oklch(0.6 0.14 160 / 35%);
+    --font: 'Geist', ui-sans-serif, system-ui, sans-serif;
+    --mono: 'Geist Mono', ui-monospace, monospace;
+  }
+
+  *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+  html { font-size: 16px; -webkit-font-smoothing: antialiased; }
+
+  body {
+    background: var(--bg);
+    color: var(--fg);
+    font-family: var(--font);
+    line-height: 1.55;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  /* ── Dot-grid bg matching .dot-grid ── */
+  body::before {
+    content: '';
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(circle, rgba(255,255,255,0.035) 1px, transparent 1px);
+    background-size: 24px 24px;
+    pointer-events: none;
+    z-index: 0;
+  }
+
+  /* ── Nav ── */
+  nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: rgba(26,26,24,0.85);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--border);
+  }
+  .nav-inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 24px;
+    height: 52px;
+    display: flex;
+    align-items: center;
+    gap: 20px;
+  }
+  .logo {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-decoration: none;
+    color: var(--fg);
+  }
+  .logo-mark {
+    width: 22px;
+    height: 22px;
+    border-radius: 5px;
+    background: #10b981;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+  }
+  .logo-mark svg { width: 13px; height: 13px; fill: white; }
+  .logo-name {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--fg);
+  }
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    list-style: none;
+  }
+  .nav-links a {
+    font-size: 13px;
+    color: var(--fg-muted);
+    text-decoration: none;
+    padding: 4px 10px;
+    border-radius: var(--radius);
+    transition: color 0.15s, background 0.15s;
+  }
+  .nav-links a:hover { color: var(--fg); background: rgba(255,255,255,0.06); }
+  .nav-spacer { flex: 1; }
+  .nav-cta {
+    font-size: 13px;
+    font-weight: 500;
+    font-family: var(--font);
+    color: var(--bg);
+    background: var(--fg);
+    border: none;
+    border-radius: var(--radius);
+    padding: 6px 14px;
+    cursor: pointer;
+    text-decoration: none;
+    transition: opacity 0.15s;
+  }
+  .nav-cta:hover { opacity: 0.85; }
+
+  /* ── Main container ── */
+  main {
+    position: relative;
+    z-index: 1;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 56px 24px 80px;
+  }
+
+  .page-wrap {
+    width: 100%;
+    max-width: 620px;
+  }
+
+  /* ── Dev escape hatch ── */
+  .dev-escape {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: var(--fg-dim);
+    text-decoration: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 5px 10px;
+    margin-bottom: 36px;
+    transition: color 0.15s, border-color 0.15s;
+    font-family: var(--mono);
+  }
+  .dev-escape:hover { color: var(--fg-muted); border-color: var(--border-hi); }
+  .dev-escape svg { width: 12px; height: 12px; opacity: 0.6; }
+
+  /* ── Hero header ── */
+  .hero-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    background: var(--green-dim);
+    border: 1px solid var(--green-border);
+    border-radius: 100px;
+    padding: 4px 12px 4px 8px;
+    font-size: 11.5px;
+    font-weight: 500;
+    color: oklch(0.78 0.13 160);
+    margin-bottom: 20px;
+  }
+  .hero-badge-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: oklch(0.7 0.15 160);
+    flex-shrink: 0;
+    box-shadow: 0 0 6px oklch(0.7 0.15 160 / 60%);
+  }
+
+  h1 {
+    font-size: clamp(26px, 4vw, 36px);
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    line-height: 1.12;
+    color: var(--fg);
+    margin-bottom: 12px;
+  }
+  .hero-sub {
+    font-size: 15px;
+    color: var(--fg-muted);
+    line-height: 1.5;
+    margin-bottom: 32px;
+    max-width: 460px;
+  }
+
+  /* ── Trust strip ── */
+  .trust-strip {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    flex-wrap: wrap;
+    margin-bottom: 40px;
+    font-size: 12px;
+    color: var(--fg-dim);
+  }
+  .trust-item {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    padding: 0 10px;
+    border-right: 1px solid var(--border);
+  }
+  .trust-item:first-child { padding-left: 0; }
+  .trust-item:last-child { border-right: none; }
+  .trust-icon { width: 13px; height: 13px; opacity: 0.6; }
+
+  /* ── Card ── */
+  .card {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-2xl);
+    padding: 28px;
+    transition: border-color 0.2s;
+  }
+
+  /* ── Step 1: URL hero input ── */
+  .url-input-wrap {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background: var(--input-bg);
+    border: 1.5px solid var(--border-hi);
+    border-radius: var(--radius-xl);
+    transition: border-color 0.2s, box-shadow 0.2s;
+    padding: 4px 4px 4px 0;
+  }
+  .url-input-wrap:focus-within {
+    border-color: oklch(0.7 0.15 160 / 50%);
+    box-shadow: 0 0 0 3px oklch(0.7 0.15 160 / 8%);
+  }
+  .url-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: var(--fg);
+    font-family: var(--font);
+    font-size: 15px;
+    padding: 12px 16px;
+    min-width: 0;
+  }
+  .url-input::placeholder { color: var(--fg-dim); }
+  .autofill-btn {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    background: var(--fg);
+    color: var(--bg);
+    font-family: var(--font);
+    font-size: 13.5px;
+    font-weight: 600;
+    border: none;
+    border-radius: calc(var(--radius-xl) - 6px);
+    padding: 10px 18px;
+    cursor: pointer;
+    transition: opacity 0.15s, transform 0.1s;
+    white-space: nowrap;
+  }
+  .autofill-btn:hover { opacity: 0.88; }
+  .autofill-btn:active { transform: scale(0.98); }
+  .autofill-btn svg { width: 15px; height: 15px; }
+
+  /* Spark icon animation */
+  .spark-icon {
+    display: inline-block;
+    transition: transform 0.3s;
+  }
+  .autofill-btn:hover .spark-icon { transform: rotate(15deg) scale(1.15); }
+
+  /* ── Loading state ── */
+  .loading-bar-wrap {
+    height: 2px;
+    background: rgba(255,255,255,0.06);
+    border-radius: 2px;
+    overflow: hidden;
+    margin-top: 16px;
+    display: none;
+  }
+  .loading-bar-wrap.active { display: block; }
+  .loading-bar {
+    height: 100%;
+    background: linear-gradient(90deg, transparent, oklch(0.7 0.15 160), transparent);
+    border-radius: 2px;
+    animation: shimmer 1.4s infinite;
+    width: 50%;
+  }
+  @keyframes shimmer {
+    0% { transform: translateX(-200%); }
+    100% { transform: translateX(400%); }
+  }
+  .loading-label {
+    margin-top: 10px;
+    font-size: 12.5px;
+    color: var(--fg-dim);
+    display: none;
+    align-items: center;
+    gap: 6px;
+  }
+  .loading-label.active { display: flex; }
+  .loading-dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: oklch(0.7 0.15 160);
+    animation: pulse 1.2s infinite;
+  }
+  @keyframes pulse { 0%,100% { opacity:0.3; } 50% { opacity:1; } }
+
+  /* ── Auto-fill reveal panel ── */
+  #form-panel {
+    display: none;
+    margin-top: 24px;
+    animation: slideDown 0.35s cubic-bezier(0.16,1,0.3,1);
+  }
+  #form-panel.visible { display: block; }
+  @keyframes slideDown {
+    from { opacity: 0; transform: translateY(-10px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+
+  .pre-fill-notice {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    background: var(--green-dim);
+    border: 1px solid var(--green-border);
+    border-radius: var(--radius-lg);
+    padding: 10px 14px;
+    font-size: 12.5px;
+    color: oklch(0.75 0.12 160);
+    margin-bottom: 20px;
+  }
+  .pre-fill-notice svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+  /* ── Form fields ── */
+  .form-section { margin-bottom: 4px; }
+
+  .field-group {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 12px;
+  }
+  @media (max-width: 520px) {
+    .field-group { grid-template-columns: 1fr; }
+  }
+
+  .field { margin-bottom: 14px; }
+  .field-label {
+    display: block;
+    font-size: 12px;
+    color: var(--fg-muted);
+    margin-bottom: 6px;
+    font-weight: 500;
+    letter-spacing: 0.01em;
+  }
+  .field-hint {
+    font-size: 11px;
+    color: var(--fg-dim);
+    margin-top: 4px;
+  }
+  .field input,
+  .field select,
+  .field textarea {
+    width: 100%;
+    background: var(--input-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    color: var(--fg);
+    font-family: var(--font);
+    font-size: 13.5px;
+    padding: 9px 12px;
+    outline: none;
+    transition: border-color 0.15s, box-shadow 0.15s;
+    appearance: none;
+  }
+  .field input:focus,
+  .field select:focus,
+  .field textarea:focus {
+    border-color: rgba(255,255,255,0.3);
+    box-shadow: 0 0 0 3px rgba(255,255,255,0.04);
+  }
+  .field input.filled,
+  .field select.filled {
+    border-color: oklch(0.6 0.14 160 / 30%);
+    background: oklch(0.55 0.14 160 / 8%);
+  }
+  .field textarea { resize: none; line-height: 1.5; }
+  .field select option { background: #1f1f1d; color: var(--fg); }
+
+  /* Earn field with selector inline */
+  .earn-row {
+    display: flex;
+    gap: 8px;
+  }
+  .earn-row input { flex: 1; }
+  .earn-row select {
+    flex: 0 0 auto;
+    width: auto;
+    padding-right: 28px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23b5b4b0' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='m6 9 6 6 6-6'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    padding-right: 28px;
+  }
+
+  /* ── Divider ── */
+  .field-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 20px 0;
+  }
+
+  /* ── Advanced disclosure ── */
+  .advanced-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12.5px;
+    color: var(--fg-dim);
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 6px 12px;
+    cursor: pointer;
+    font-family: var(--font);
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+    margin-bottom: 0;
+  }
+  .advanced-toggle:hover {
+    color: var(--fg-muted);
+    border-color: var(--border-hi);
+    background: rgba(255,255,255,0.04);
+  }
+  .advanced-toggle svg {
+    width: 13px;
+    height: 13px;
+    transition: transform 0.2s;
+  }
+  .advanced-toggle.open svg { transform: rotate(90deg); }
+
+  #advanced-fields {
+    display: none;
+    margin-top: 16px;
+    animation: slideDown 0.25s cubic-bezier(0.16,1,0.3,1);
+  }
+  #advanced-fields.open { display: block; }
+
+  /* ── Email + identity section ── */
+  .identity-section {
+    background: rgba(255,255,255,0.025);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 18px 20px;
+    margin-top: 20px;
+    margin-bottom: 20px;
+  }
+  .identity-label-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+  .identity-label-row svg { width: 14px; height: 14px; color: var(--fg-muted); }
+  .identity-title {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+  }
+  .identity-sub {
+    font-size: 12px;
+    color: var(--fg-dim);
+    margin-top: 2px;
+  }
+  .checkbox-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 12px;
+  }
+  .checkbox-row input[type="checkbox"] {
+    width: 15px;
+    height: 15px;
+    accent-color: oklch(0.7 0.15 160);
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .checkbox-row label {
+    font-size: 12.5px;
+    color: var(--fg-muted);
+    cursor: pointer;
+    user-select: none;
+  }
+  .badge-inline {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    font-size: 10.5px;
+    font-weight: 600;
+    color: oklch(0.62 0.16 230);
+    background: oklch(0.62 0.16 230 / 12%);
+    border: 1px solid oklch(0.62 0.16 230 / 25%);
+    border-radius: 4px;
+    padding: 1px 5px;
+    vertical-align: middle;
+    margin-left: 3px;
+  }
+
+  /* ── Submit button ── */
+  .submit-btn {
+    width: 100%;
+    background: var(--fg);
+    color: var(--bg);
+    font-family: var(--font);
+    font-size: 15px;
+    font-weight: 700;
+    border: none;
+    border-radius: var(--radius-xl);
+    padding: 14px 24px;
+    cursor: pointer;
+    transition: opacity 0.15s, transform 0.1s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    letter-spacing: -0.01em;
+  }
+  .submit-btn:hover { opacity: 0.88; }
+  .submit-btn:active { transform: scale(0.99); }
+  .submit-btn svg { width: 16px; height: 16px; }
+
+  .submit-note {
+    text-align: center;
+    font-size: 11.5px;
+    color: var(--fg-dim);
+    margin-top: 10px;
+  }
+
+  /* ── Success state ── */
+  #success-panel {
+    display: none;
+    text-align: center;
+    animation: slideDown 0.4s cubic-bezier(0.16,1,0.3,1);
+  }
+  #success-panel.visible { display: block; }
+
+  .success-icon-wrap {
+    width: 64px;
+    height: 64px;
+    border-radius: 50%;
+    background: var(--green-dim);
+    border: 1px solid var(--green-border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto 20px;
+  }
+  .success-icon-wrap svg { width: 28px; height: 28px; }
+
+  .success-h {
+    font-size: 24px;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+    color: var(--fg);
+    margin-bottom: 10px;
+  }
+  .success-sub {
+    font-size: 14px;
+    color: var(--fg-muted);
+    line-height: 1.55;
+    max-width: 400px;
+    margin: 0 auto 32px;
+  }
+  .success-sub strong { color: var(--fg); font-weight: 600; }
+
+  .what-next {
+    background: var(--bg2);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-xl);
+    padding: 20px 22px;
+    text-align: left;
+    margin-bottom: 24px;
+  }
+  .what-next-title {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-dim);
+    margin-bottom: 14px;
+  }
+  .next-steps { list-style: none; }
+  .next-steps li {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 10px 0;
+    border-bottom: 1px solid var(--border);
+    font-size: 13.5px;
+    color: var(--fg-muted);
+    line-height: 1.45;
+  }
+  .next-steps li:last-child { border-bottom: none; padding-bottom: 0; }
+  .step-number {
+    flex-shrink: 0;
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: rgba(255,255,255,0.06);
+    border: 1px solid var(--border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--fg-muted);
+    margin-top: 0px;
+  }
+  .step-text strong { color: var(--fg); }
+
+  .back-link {
+    font-size: 13px;
+    color: var(--fg-dim);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    transition: color 0.15s;
+  }
+  .back-link:hover { color: var(--fg-muted); }
+
+  /* ── Footer ── */
+  footer {
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid var(--border);
+    padding: 24px;
+    text-align: center;
+  }
+  footer .footer-inner {
+    max-width: 620px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 20px;
+    flex-wrap: wrap;
+  }
+  footer a {
+    font-size: 12px;
+    color: var(--fg-dim);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  footer a:hover { color: var(--fg-muted); }
+  footer .sep { color: var(--border); }
+
+  /* ── Responsive ── */
+  @media (max-width: 480px) {
+    main { padding: 36px 16px 64px; }
+    .card { padding: 20px; }
+    .url-input { font-size: 14px; }
+    .autofill-btn { font-size: 12.5px; padding: 9px 14px; }
+    h1 { font-size: 26px; }
+    .trust-strip { gap: 4px; }
+    .trust-item { padding: 2px 8px; font-size: 11px; }
+  }
+
+  /* ── Demo button (for mockup state toggle) ── */
+  .demo-controls {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    z-index: 100;
+    display: flex;
+    gap: 8px;
+  }
+  .demo-btn {
+    font-size: 11px;
+    font-family: var(--mono);
+    background: #252523;
+    color: var(--fg-muted);
+    border: 1px solid var(--border-hi);
+    border-radius: var(--radius);
+    padding: 6px 11px;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s;
+  }
+  .demo-btn:hover { background: #2f2f2c; color: var(--fg); }
+</style>
+</head>
+<body>
+
+<!-- Nav -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="logo">
+      <div class="logo-mark">
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+          <circle cx="8" cy="8" r="3" fill="white"/>
+          <path d="M8 2 L8 5 M8 11 L8 14 M2 8 L5 8 M11 8 L14 8" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+      </div>
+      <span class="logo-name">OpenAffiliate</span>
+    </a>
+    <nav>
+      <ul class="nav-links">
+        <li><a href="/programs">Programs</a></li>
+        <li><a href="/categories">Categories</a></li>
+        <li><a href="/rankings">Rankings</a></li>
+      </ul>
+    </nav>
+    <div class="nav-spacer"></div>
+    <a href="/programs" class="nav-cta">Browse Programs</a>
+  </div>
+</nav>
+
+<!-- Main -->
+<main>
+  <div class="page-wrap">
+
+    <!-- Developer escape hatch -->
+    <a href="https://github.com/Affitor/open-affiliate" class="dev-escape">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+      Developer? List via GitHub
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+    </a>
+
+    <!-- ── SUBMIT FLOW ── -->
+    <div id="submit-flow">
+
+      <!-- Hero header -->
+      <div class="hero-badge">
+        <span class="hero-badge-dot"></span>
+        750+ programs listed · Free forever
+      </div>
+
+      <h1>List your affiliate program.</h1>
+      <p class="hero-sub">Paste your affiliates page URL. We'll read it and fill in the details for you — takes about 30 seconds.</p>
+
+      <!-- Trust strip -->
+      <div class="trust-strip">
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Free forever
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+          750+ programs
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>
+          Usually live in minutes
+        </span>
+        <span class="trust-item">
+          <svg class="trust-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+          Discovered by AI agents
+        </span>
+      </div>
+
+      <!-- Card -->
+      <div class="card">
+
+        <!-- Step 1: URL input -->
+        <div id="url-step">
+          <div class="field-label" style="margin-bottom: 10px; font-size: 13px; color: var(--fg-muted);">
+            Your affiliate program page URL
+          </div>
+          <div class="url-input-wrap">
+            <input
+              id="url-input"
+              class="url-input"
+              type="url"
+              placeholder="e.g. yourproduct.com/affiliates"
+              value=""
+              autocomplete="off"
+              spellcheck="false"
+            >
+            <button class="autofill-btn" onclick="doAutofill()">
+              <span class="spark-icon">
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+              </span>
+              Auto-fill with AI
+            </button>
+          </div>
+
+          <!-- Loading bar -->
+          <div class="loading-bar-wrap" id="loading-bar-wrap">
+            <div class="loading-bar"></div>
+          </div>
+          <div class="loading-label" id="loading-label">
+            <span class="loading-dot"></span>
+            Reading your affiliates page...
+          </div>
+        </div>
+
+        <!-- Step 2: Pre-filled form panel (appears after auto-fill) -->
+        <div id="form-panel">
+
+          <!-- Pre-fill success notice -->
+          <div class="pre-fill-notice">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="oklch(0.7 0.15 160)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3z"/></svg>
+            We pre-filled what we found. Review and adjust anything that looks off.
+          </div>
+
+          <!-- 6 essentials -->
+          <div class="form-section">
+
+            <div class="field">
+              <label class="field-label">Program name</label>
+              <input type="text" class="filled" value="Notion" id="f-name">
+            </div>
+
+            <div class="field-group">
+              <div class="field">
+                <label class="field-label">Your website</label>
+                <input type="url" class="filled" value="notion.so" id="f-url">
+              </div>
+              <div class="field">
+                <label class="field-label">Category</label>
+                <select class="filled" id="f-category">
+                  <option>Productivity</option>
+                  <option>Developer Tools</option>
+                  <option>Email Marketing</option>
+                  <option>CRM &amp; Sales</option>
+                  <option>Design</option>
+                  <option>Analytics</option>
+                  <option>E-commerce</option>
+                  <option>Finance</option>
+                  <option>Security</option>
+                  <option>AI &amp; Machine Learning</option>
+                  <option>Project Management</option>
+                  <option>Communication</option>
+                  <option>HR &amp; Recruiting</option>
+                  <option>Data &amp; BI</option>
+                  <option>Video &amp; Media</option>
+                  <option>Other</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field-label">What do affiliates earn?</label>
+              <div class="earn-row">
+                <input type="text" class="filled" value="50" id="f-earn-amount" placeholder="e.g. 25">
+                <select class="filled" id="f-earn-type">
+                  <option value="pct-recurring">% of revenue, recurring</option>
+                  <option value="pct-onetime">% of first sale, one-time</option>
+                  <option value="flat">Flat $ per referral</option>
+                </select>
+              </div>
+              <p class="field-hint">e.g. "25% of revenue, recurring" or "$50 flat per signup"</p>
+            </div>
+
+            <div class="field">
+              <label class="field-label">How long is a referral tracked?</label>
+              <div class="earn-row">
+                <input type="number" class="filled" value="90" id="f-cookie" min="1" max="730" style="max-width: 100px;">
+                <span style="font-size:13.5px; color: var(--fg-muted); display:flex; align-items:center; padding: 0 4px;">days</span>
+                <span style="font-size:12px; color:var(--fg-dim); display:flex; align-items:center; flex:1;">After someone clicks your link, this is how long you get credit for their signup.</span>
+              </div>
+            </div>
+
+            <div class="field">
+              <label class="field-label">One-line pitch <span style="color:var(--fg-dim); font-weight:400;">(shown on your listing)</span></label>
+              <input type="text" class="filled" value="The connected workspace for notes, docs, and projects." id="f-pitch" maxlength="120">
+              <p class="field-hint" id="pitch-count">56 / 120 characters</p>
+            </div>
+
+          </div><!-- /form-section -->
+
+          <hr class="field-divider">
+
+          <!-- Advanced / optional -->
+          <button class="advanced-toggle" id="advanced-toggle-btn" onclick="toggleAdvanced()">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg>
+            Add more details (optional)
+          </button>
+          <div id="advanced-fields">
+            <div class="field-group">
+              <div class="field">
+                <label class="field-label">Minimum payout</label>
+                <input type="text" value="$50" id="f-min-payout" placeholder="e.g. $50">
+                <p class="field-hint">The minimum balance needed before affiliates get paid.</p>
+              </div>
+              <div class="field">
+                <label class="field-label">How often are affiliates paid?</label>
+                <select id="f-payout-freq">
+                  <option>Monthly</option>
+                  <option>Every 2 weeks</option>
+                  <option>Net 30 (30 days after the month closes)</option>
+                  <option>Net 60</option>
+                </select>
+              </div>
+            </div>
+            <div class="field">
+              <label class="field-label">Affiliate signup link <span style="color:var(--fg-dim); font-weight:400;">(where affiliates apply)</span></label>
+              <input type="url" value="notion.so/affiliates" id="f-signup-url" placeholder="yourproduct.com/affiliates">
+            </div>
+            <div class="field">
+              <label class="field-label">Any restrictions or requirements? <span style="color:var(--fg-dim); font-weight:400;">(optional)</span></label>
+              <textarea rows="2" id="f-restrictions" placeholder="e.g. US &amp; EU only · Must have 1k+ followers · No paid search"></textarea>
+            </div>
+          </div>
+
+          <!-- Identity / email -->
+          <div class="identity-section">
+            <div class="identity-label-row">
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07A19.5 19.5 0 0 1 4.99 12 19.79 19.79 0 0 1 1.93 3.47 2 2 0 0 1 3.9 1.27h3a2 2 0 0 1 2 1.72c.127.96.361 1.903.7 2.81a2 2 0 0 1-.45 2.11L8.09 8a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.907.339 1.85.573 2.81.7A2 2 0 0 1 22 14.9z"/></svg>
+              <div>
+                <div class="identity-title">Where should we send your listing link?</div>
+                <div class="identity-sub">We'll email you a magic link so you can edit or claim your listing later. No password needed.</div>
+              </div>
+            </div>
+            <div class="field" style="margin-bottom: 0;">
+              <input type="email" id="f-email" placeholder="you@yourcompany.com" style="font-size:14px;">
+            </div>
+            <div class="checkbox-row">
+              <input type="checkbox" id="works-here" checked>
+              <label for="works-here">
+                I work at this company
+                <span class="badge-inline">
+                  <svg xmlns="http://www.w3.org/2000/svg" width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg>
+                  Verified badge later
+                </span>
+              </label>
+            </div>
+          </div>
+
+          <!-- Submit -->
+          <button class="submit-btn" onclick="doSubmit()">
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m22 2-7 20-4-9-9-4 20-7z"/><path d="M22 2 11 13"/></svg>
+            Submit for review
+          </button>
+          <p class="submit-note">Usually live within a few minutes. We review every submission.</p>
+
+        </div><!-- /form-panel -->
+      </div><!-- /card -->
+
+    </div><!-- /submit-flow -->
+
+    <!-- ── SUCCESS STATE ── -->
+    <div id="success-panel">
+      <div class="card" style="padding: 40px 28px;">
+
+        <div class="success-icon-wrap">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="oklch(0.7 0.15 160)" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" width="28" height="28"><path d="M20 6 9 17l-5-5"/></svg>
+        </div>
+
+        <div class="success-h">You're in the queue.</div>
+        <p class="success-sub">
+          <strong>Notion</strong> has been submitted. Check your email — we'll send you a link to track your listing and make edits.
+        </p>
+
+        <div class="what-next">
+          <div class="what-next-title">What happens next</div>
+          <ul class="next-steps">
+            <li>
+              <span class="step-number">1</span>
+              <span class="step-text"><strong>Auto-review</strong> — our bot checks the basics (commission ≥ 1%, working URL, no duplicates). Usually takes under a minute.</span>
+            </li>
+            <li>
+              <span class="step-number">2</span>
+              <span class="step-text"><strong>Goes live</strong> — once approved, your program appears on OpenAffiliate and gets indexed by AI agents and discovery tools.</span>
+            </li>
+            <li>
+              <span class="step-number">3</span>
+              <span class="step-text"><strong>Claim your listing</strong> — click the link in your email to verify you own this program and unlock the <span class="badge-inline" style="font-size:10px;">Verified</span> badge.</span>
+            </li>
+          </ul>
+        </div>
+
+        <a href="/programs" class="back-link">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="14" height="14"><path d="m15 18-6-6 6-6"/></svg>
+          Browse all programs
+        </a>
+
+      </div>
+    </div><!-- /success-panel -->
+
+  </div>
+</main>
+
+<!-- Footer -->
+<footer>
+  <div class="footer-inner">
+    <a href="/programs">Browse programs</a>
+    <span class="sep">·</span>
+    <a href="/docs">Docs</a>
+    <span class="sep">·</span>
+    <a href="https://github.com/Affitor/open-affiliate">GitHub</a>
+    <span class="sep">·</span>
+    <a href="/feedback">Feedback</a>
+    <span class="sep">·</span>
+    <a href="https://github.com/Affitor/open-affiliate" style="font-family: var(--mono); font-size: 11px; color: var(--fg-dim);">Developer? List via GitHub →</a>
+  </div>
+</footer>
+
+<!-- Mockup state controls -->
+<div class="demo-controls">
+  <button class="demo-btn" onclick="showForm()">Show form</button>
+  <button class="demo-btn" onclick="showSuccess()">Show success</button>
+  <button class="demo-btn" onclick="resetAll()">Reset</button>
+</div>
+
+<script>
+  // ── State ──
+  const DEMO_PREFILL = {
+    name: 'Notion',
+    url: 'notion.so',
+    category: 'Productivity',
+    earnAmount: '50',
+    earnType: 'pct-recurring',
+    cookie: '90',
+    pitch: 'The connected workspace for notes, docs, and projects.'
+  };
+
+  // ── Pitch character counter ──
+  const pitchInput = document.getElementById('f-pitch');
+  const pitchCount = document.getElementById('pitch-count');
+  if (pitchInput && pitchCount) {
+    pitchInput.addEventListener('input', () => {
+      pitchCount.textContent = `${pitchInput.value.length} / 120 characters`;
+    });
+  }
+
+  // ── Auto-fill simulation ──
+  function doAutofill() {
+    const url = document.getElementById('url-input').value.trim();
+    if (!url) {
+      document.getElementById('url-input').focus();
+      document.getElementById('url-input').style.borderColor = 'oklch(0.7 0.2 30 / 60%)';
+      setTimeout(() => { document.getElementById('url-input').style.borderColor = ''; }, 1500);
+      return;
+    }
+    // Show loading
+    document.getElementById('loading-bar-wrap').classList.add('active');
+    document.getElementById('loading-label').classList.add('active');
+    document.querySelector('.autofill-btn').disabled = true;
+    document.querySelector('.autofill-btn').style.opacity = '0.5';
+
+    setTimeout(() => {
+      document.getElementById('loading-bar-wrap').classList.remove('active');
+      document.getElementById('loading-label').classList.remove('active');
+      document.querySelector('.autofill-btn').disabled = false;
+      document.querySelector('.autofill-btn').style.opacity = '';
+      showForm();
+    }, 1800);
+  }
+
+  function showForm() {
+    document.getElementById('form-panel').classList.add('visible');
+    // Scroll to the form panel smoothly
+    setTimeout(() => {
+      document.getElementById('form-panel').scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }, 50);
+  }
+
+  // ── Advanced toggle ──
+  function toggleAdvanced() {
+    const btn = document.getElementById('advanced-toggle-btn');
+    const panel = document.getElementById('advanced-fields');
+    btn.classList.toggle('open');
+    panel.classList.toggle('open');
+  }
+
+  // ── Submit ──
+  function doSubmit() {
+    const email = document.getElementById('f-email').value.trim();
+    if (!email || !email.includes('@')) {
+      document.getElementById('f-email').focus();
+      document.getElementById('f-email').style.borderColor = 'oklch(0.7 0.2 30 / 60%)';
+      setTimeout(() => { document.getElementById('f-email').style.borderColor = ''; }, 1500);
+      return;
+    }
+    showSuccess();
+  }
+
+  function showSuccess() {
+    document.getElementById('submit-flow').style.display = 'none';
+    document.getElementById('success-panel').classList.add('visible');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function resetAll() {
+    document.getElementById('submit-flow').style.display = 'block';
+    document.getElementById('success-panel').classList.remove('visible');
+    document.getElementById('form-panel').classList.remove('visible');
+    document.getElementById('advanced-fields').classList.remove('open');
+    document.getElementById('advanced-toggle-btn').classList.remove('open');
+    document.getElementById('loading-bar-wrap').classList.remove('active');
+    document.getElementById('loading-label').classList.remove('active');
+    document.querySelector('.autofill-btn').disabled = false;
+    document.querySelector('.autofill-btn').style.opacity = '';
+    document.getElementById('url-input').value = '';
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  // ── Enter key on URL input ──
+  document.getElementById('url-input').addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') doAutofill();
+  });
+</script>
+
+</body>
+</html>

--- a/docs/mockups/submit-v2-friendly-stepper.html
+++ b/docs/mockups/submit-v2-friendly-stepper.html
@@ -1,0 +1,1155 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>List Your Program — OpenAffiliate</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    /* ─── Design tokens (dark mode, matches globals.css) ─── */
+    :root {
+      --bg:            #131312;
+      --bg-card:       #1c1c1a;
+      --bg-muted:      #232320;
+      --bg-input:      rgba(255,255,255,0.07);
+      --bg-input-focus:rgba(255,255,255,0.10);
+      --border:        rgba(255,255,255,0.10);
+      --border-focus:  rgba(255,255,255,0.28);
+      --fg:            rgba(255,255,255,0.96);
+      --fg-muted:      rgba(255,255,255,0.50);
+      --fg-subtle:     rgba(255,255,255,0.30);
+      --accent:        #30d48a;   /* emerald-ish, the glow-card accent */
+      --accent-dim:    rgba(48,212,138,0.12);
+      --accent-border: rgba(48,212,138,0.30);
+      --radius-sm:     6px;
+      --radius:        10px;
+      --radius-lg:     14px;
+      --radius-xl:     18px;
+      --shadow-card:   0 1px 3px rgba(0,0,0,0.5), 0 0 0 1px rgba(255,255,255,0.06);
+      --shadow-btn:    0 1px 3px rgba(0,0,0,0.6);
+      --font:          'Geist', ui-sans-serif, system-ui, sans-serif;
+      --font-mono:     'Geist Mono', ui-monospace, monospace;
+      --step-done:     #30d48a;
+      --step-active:   #fff;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    html { font-family: var(--font); background: var(--bg); color: var(--fg); -webkit-font-smoothing: antialiased; }
+    body { min-height: 100vh; display: flex; flex-direction: column; }
+
+    /* ─── Dot-grid background ─── */
+    body::before {
+      content: '';
+      position: fixed; inset: 0; z-index: 0; pointer-events: none;
+      background-image: radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 24px 24px;
+    }
+
+    /* ─── Nav ─── */
+    nav {
+      position: sticky; top: 0; z-index: 50;
+      background: rgba(19,19,18,0.85); backdrop-filter: blur(20px);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-inner {
+      max-width: 1100px; margin: 0 auto;
+      display: flex; align-items: center; justify-content: space-between;
+      height: 56px; padding: 0 24px;
+    }
+    .nav-logo { display: flex; align-items: center; gap: 10px; text-decoration: none; }
+    .nav-logo-icon {
+      width: 28px; height: 28px; border-radius: 6px;
+      background: #0a0a0a; display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+      box-shadow: 0 0 0 1px rgba(255,255,255,0.08);
+    }
+    .nav-logo-icon svg { width: 16px; height: 16px; }
+    .nav-logo-text { font-size: 14px; font-weight: 600; color: var(--fg); letter-spacing: -0.02em; }
+    .nav-links { display: flex; gap: 24px; align-items: center; }
+    .nav-links a {
+      font-size: 13px; color: var(--fg-muted); text-decoration: none;
+      transition: color 0.15s;
+    }
+    .nav-links a:hover { color: var(--fg); }
+    .nav-links a.active { color: var(--fg); font-weight: 500; }
+    .nav-gh {
+      font-size: 13px; color: var(--fg-muted); text-decoration: none;
+      display: flex; align-items: center; gap: 6px; transition: color 0.15s;
+    }
+    .nav-gh:hover { color: var(--fg); }
+    .nav-gh svg { width: 16px; height: 16px; }
+
+    /* ─── Trust strip ─── */
+    .trust-strip {
+      background: rgba(48,212,138,0.06);
+      border-bottom: 1px solid rgba(48,212,138,0.12);
+      padding: 9px 24px;
+      display: flex; align-items: center; justify-content: center; gap: 0;
+      flex-wrap: wrap;
+    }
+    .trust-strip span {
+      font-size: 12px; color: rgba(48,212,138,0.85); white-space: nowrap;
+    }
+    .trust-sep {
+      font-size: 12px; color: rgba(48,212,138,0.30); margin: 0 12px;
+    }
+
+    /* ─── Page container ─── */
+    main { position: relative; z-index: 1; flex: 1; }
+    .page-wrap {
+      max-width: 640px; margin: 0 auto;
+      padding: 48px 24px 80px;
+    }
+
+    /* ─── Dev escape hatch ─── */
+    .dev-link {
+      display: inline-flex; align-items: center; gap: 6px;
+      font-size: 12px; color: var(--fg-subtle); text-decoration: none;
+      border: 1px solid var(--border); border-radius: var(--radius-sm);
+      padding: 5px 10px; transition: color 0.15s, border-color 0.15s;
+      margin-bottom: 32px;
+    }
+    .dev-link:hover { color: var(--fg-muted); border-color: rgba(255,255,255,0.18); }
+    .dev-link svg { width: 12px; height: 12px; }
+
+    /* ─── Header ─── */
+    .page-header { margin-bottom: 36px; }
+    .page-header h1 {
+      font-size: 26px; font-weight: 700; letter-spacing: -0.03em;
+      color: var(--fg); line-height: 1.2;
+    }
+    .page-header p {
+      margin-top: 8px; font-size: 15px; color: var(--fg-muted); line-height: 1.6;
+    }
+
+    /* ─── Progress stepper ─── */
+    .stepper {
+      display: flex; align-items: center; gap: 0;
+      margin-bottom: 36px;
+    }
+    .step-item {
+      display: flex; flex-direction: column; align-items: center; position: relative; flex: 1;
+    }
+    .step-item:not(:last-child)::after {
+      content: '';
+      position: absolute; top: 14px; left: calc(50% + 18px);
+      right: calc(-50% + 18px);
+      height: 1px;
+      background: var(--border);
+      transition: background 0.3s;
+    }
+    .step-item.done:not(:last-child)::after {
+      background: linear-gradient(90deg, var(--step-done), rgba(48,212,138,0.3));
+    }
+    .step-circle {
+      width: 28px; height: 28px; border-radius: 50%;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 12px; font-weight: 600;
+      background: var(--bg-muted); border: 1.5px solid var(--border);
+      color: var(--fg-muted);
+      transition: all 0.25s ease;
+      position: relative; z-index: 1;
+    }
+    .step-item.active .step-circle {
+      background: var(--fg); border-color: var(--fg); color: var(--bg);
+    }
+    .step-item.done .step-circle {
+      background: var(--accent); border-color: var(--accent); color: #000;
+    }
+    .step-label {
+      margin-top: 7px; font-size: 11px; font-weight: 500;
+      color: var(--fg-subtle); text-align: center; letter-spacing: 0.01em;
+      transition: color 0.2s;
+    }
+    .step-item.active .step-label { color: var(--fg-muted); }
+    .step-item.done .step-label { color: var(--accent); }
+
+    /* ─── Step panel ─── */
+    .step-panel {
+      display: none; animation: fadeUp 0.28s ease;
+    }
+    .step-panel.visible { display: block; }
+
+    @keyframes fadeUp {
+      from { opacity: 0; transform: translateY(12px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    /* ─── Section card ─── */
+    .card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 28px;
+      box-shadow: var(--shadow-card);
+      margin-bottom: 16px;
+    }
+
+    /* ─── Step heading ─── */
+    .step-heading {
+      font-size: 17px; font-weight: 700; color: var(--fg);
+      letter-spacing: -0.02em; margin-bottom: 4px;
+    }
+    .step-sub {
+      font-size: 13px; color: var(--fg-muted); margin-bottom: 24px; line-height: 1.5;
+    }
+
+    /* ─── Magic URL fetch block ─── */
+    .fetch-block {
+      background: linear-gradient(135deg, rgba(48,212,138,0.07) 0%, rgba(48,212,138,0.02) 100%);
+      border: 1.5px solid rgba(48,212,138,0.22);
+      border-radius: var(--radius-lg);
+      padding: 20px;
+      margin-bottom: 24px;
+    }
+    .fetch-label {
+      font-size: 12px; font-weight: 600; color: var(--accent);
+      text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 10px;
+      display: flex; align-items: center; gap: 6px;
+    }
+    .fetch-label svg { width: 13px; height: 13px; }
+    .fetch-row {
+      display: flex; gap: 8px; align-items: stretch;
+    }
+    .fetch-input {
+      flex: 1;
+      background: rgba(255,255,255,0.06);
+      border: 1.5px solid rgba(48,212,138,0.20);
+      border-radius: var(--radius-sm);
+      padding: 10px 14px;
+      font-size: 14px; font-family: var(--font); color: var(--fg);
+      outline: none; transition: border-color 0.15s, background 0.15s;
+    }
+    .fetch-input::placeholder { color: rgba(255,255,255,0.25); }
+    .fetch-input:focus { border-color: var(--accent); background: rgba(48,212,138,0.06); }
+    .btn-fetch {
+      background: var(--accent); color: #000;
+      border: none; border-radius: var(--radius-sm);
+      padding: 10px 18px; font-size: 13px; font-weight: 600;
+      font-family: var(--font); cursor: pointer; white-space: nowrap;
+      transition: opacity 0.15s, transform 0.1s;
+      display: flex; align-items: center; gap: 6px;
+    }
+    .btn-fetch:hover { opacity: 0.90; }
+    .btn-fetch:active { transform: scale(0.97); }
+    .btn-fetch svg { width: 14px; height: 14px; }
+    .fetch-hint {
+      font-size: 11.5px; color: rgba(48,212,138,0.55); margin-top: 8px;
+    }
+
+    /* ─── Autofill preview chip ─── */
+    .autofill-chip {
+      display: none;
+      margin-top: 12px;
+      background: rgba(48,212,138,0.08);
+      border: 1px solid rgba(48,212,138,0.20);
+      border-radius: var(--radius-sm);
+      padding: 10px 14px;
+      font-size: 12.5px; color: rgba(48,212,138,0.85);
+      display: none; align-items: center; gap: 8px;
+    }
+    .autofill-chip.visible { display: flex; animation: fadeUp 0.22s ease; }
+    .autofill-chip svg { width: 14px; height: 14px; flex-shrink: 0; }
+
+    /* ─── Fieldset ─── */
+    .field { margin-bottom: 18px; }
+    .field:last-child { margin-bottom: 0; }
+    .field label {
+      display: block; font-size: 12px; font-weight: 500;
+      color: var(--fg-muted); margin-bottom: 7px; letter-spacing: 0.01em;
+    }
+    .field label .required { color: var(--fg-subtle); margin-left: 3px; }
+    .field input, .field select, .field textarea {
+      width: 100%; background: var(--bg-input);
+      border: 1.5px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 10px 13px;
+      font-size: 14px; font-family: var(--font); color: var(--fg);
+      outline: none; transition: border-color 0.15s, background 0.15s;
+      appearance: none; -webkit-appearance: none;
+    }
+    .field input::placeholder, .field textarea::placeholder { color: var(--fg-subtle); }
+    .field input:focus, .field select:focus, .field textarea:focus {
+      border-color: var(--border-focus);
+      background: var(--bg-input-focus);
+    }
+    .field select {
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='rgba(255,255,255,0.35)' stroke-width='2.5'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 13px center;
+      padding-right: 36px;
+      cursor: pointer;
+    }
+    .field select option { background: #1c1c1a; color: var(--fg); }
+    .field textarea { resize: none; line-height: 1.6; }
+    .field-hint {
+      margin-top: 6px; font-size: 11.5px; color: var(--fg-subtle); line-height: 1.5;
+    }
+    .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    @media (max-width: 480px) { .field-row { grid-template-columns: 1fr; } }
+
+    /* ─── Commission row ─── */
+    .commission-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+    @media (max-width: 480px) { .commission-grid { grid-template-columns: 1fr; } }
+
+    .input-with-suffix { position: relative; }
+    .input-with-suffix input { padding-right: 42px; }
+    .input-suffix {
+      position: absolute; right: 13px; top: 50%; transform: translateY(-50%);
+      font-size: 13px; color: var(--fg-subtle); pointer-events: none;
+    }
+
+    /* ─── Cookie window slider ─── */
+    .cookie-picker { display: flex; flex-direction: column; gap: 8px; }
+    .cookie-options { display: flex; gap: 8px; flex-wrap: wrap; }
+    .cookie-opt {
+      padding: 7px 13px; border-radius: var(--radius-sm);
+      border: 1.5px solid var(--border);
+      background: transparent; color: var(--fg-muted);
+      font-size: 13px; font-family: var(--font); cursor: pointer;
+      transition: all 0.15s;
+    }
+    .cookie-opt:hover { border-color: rgba(255,255,255,0.22); color: var(--fg); }
+    .cookie-opt.selected {
+      border-color: var(--fg); background: rgba(255,255,255,0.06);
+      color: var(--fg); font-weight: 500;
+    }
+    .cookie-custom { display: flex; align-items: center; gap: 8px; }
+    .cookie-custom input {
+      width: 90px; background: var(--bg-input); border: 1.5px solid var(--border);
+      border-radius: var(--radius-sm); padding: 8px 12px;
+      font-size: 13px; font-family: var(--font); color: var(--fg); outline: none;
+      transition: border-color 0.15s;
+    }
+    .cookie-custom input:focus { border-color: var(--border-focus); }
+    .cookie-custom span { font-size: 13px; color: var(--fg-muted); }
+
+    /* ─── Advanced details accordion ─── */
+    .accordion-toggle {
+      display: flex; align-items: center; gap: 8px;
+      font-size: 13px; color: var(--fg-muted);
+      cursor: pointer; user-select: none;
+      padding: 10px 0; border: none; background: none;
+      font-family: var(--font); transition: color 0.15s; width: 100%;
+    }
+    .accordion-toggle:hover { color: var(--fg); }
+    .accordion-toggle svg { width: 14px; height: 14px; transition: transform 0.2s; flex-shrink: 0; }
+    .accordion-toggle.open svg { transform: rotate(180deg); }
+    .accordion-body {
+      display: none; padding-top: 4px;
+    }
+    .accordion-body.open { display: block; animation: fadeUp 0.2s ease; }
+    .accordion-divider {
+      height: 1px; background: var(--border); margin: 4px 0 16px;
+    }
+
+    /* ─── Email magic-link card ─── */
+    .email-hero {
+      text-align: center; padding: 8px 0 20px;
+    }
+    .email-hero .icon-ring {
+      width: 56px; height: 56px; border-radius: 50%;
+      border: 1.5px solid var(--border);
+      background: var(--bg-muted);
+      display: flex; align-items: center; justify-content: center;
+      margin: 0 auto 16px; color: var(--fg-muted);
+    }
+    .email-hero .icon-ring svg { width: 24px; height: 24px; }
+    .email-hero h3 {
+      font-size: 16px; font-weight: 700; letter-spacing: -0.02em;
+      margin-bottom: 6px;
+    }
+    .email-hero p {
+      font-size: 13px; color: var(--fg-muted); line-height: 1.55;
+    }
+
+    /* ─── Checkbox ─── */
+    .checkbox-row {
+      display: flex; align-items: flex-start; gap: 11px;
+      margin-top: 14px; cursor: pointer;
+    }
+    .checkbox-row input[type="checkbox"] {
+      width: 16px; height: 16px; flex-shrink: 0;
+      accent-color: var(--accent); margin-top: 2px; cursor: pointer;
+    }
+    .checkbox-row span {
+      font-size: 13px; color: var(--fg-muted); line-height: 1.5; cursor: pointer;
+    }
+    .checkbox-row span strong { color: var(--fg); font-weight: 500; }
+
+    /* ─── Review summary ─── */
+    .review-summary {
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 18px 20px;
+      margin-top: 20px;
+    }
+    .review-summary h4 {
+      font-size: 11px; font-weight: 600; color: var(--fg-subtle);
+      text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 12px;
+    }
+    .review-row {
+      display: flex; justify-content: space-between; align-items: baseline;
+      gap: 12px; padding: 6px 0;
+      border-bottom: 1px solid rgba(255,255,255,0.05);
+    }
+    .review-row:last-child { border-bottom: none; }
+    .review-key { font-size: 12px; color: var(--fg-muted); flex-shrink: 0; }
+    .review-val {
+      font-size: 13px; color: var(--fg); font-weight: 500;
+      text-align: right; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+    }
+
+    /* ─── Navigation buttons ─── */
+    .btn-row {
+      display: flex; align-items: center; justify-content: space-between;
+      margin-top: 24px; gap: 12px;
+    }
+    .btn-back {
+      background: transparent; border: 1.5px solid var(--border);
+      border-radius: var(--radius-sm);
+      padding: 11px 20px; font-size: 14px; font-weight: 500;
+      font-family: var(--font); color: var(--fg-muted); cursor: pointer;
+      transition: border-color 0.15s, color 0.15s;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .btn-back:hover { border-color: rgba(255,255,255,0.22); color: var(--fg); }
+    .btn-back svg { width: 15px; height: 15px; }
+    .btn-next {
+      background: var(--fg); color: var(--bg);
+      border: none; border-radius: var(--radius-sm);
+      padding: 11px 24px; font-size: 14px; font-weight: 600;
+      font-family: var(--font); cursor: pointer;
+      transition: opacity 0.15s, transform 0.1s;
+      display: flex; align-items: center; gap: 8px;
+      box-shadow: var(--shadow-btn);
+    }
+    .btn-next:hover { opacity: 0.90; }
+    .btn-next:active { transform: scale(0.97); }
+    .btn-next svg { width: 15px; height: 15px; }
+    .btn-submit {
+      background: var(--accent); color: #000;
+      border: none; border-radius: var(--radius-sm);
+      padding: 13px 28px; font-size: 14px; font-weight: 700;
+      font-family: var(--font); cursor: pointer;
+      transition: opacity 0.15s, transform 0.1s, box-shadow 0.2s;
+      display: flex; align-items: center; gap: 8px;
+      box-shadow: 0 0 20px rgba(48,212,138,0.25);
+    }
+    .btn-submit:hover { opacity: 0.92; box-shadow: 0 0 28px rgba(48,212,138,0.35); }
+    .btn-submit:active { transform: scale(0.97); }
+    .btn-submit svg { width: 15px; height: 15px; }
+
+    /* ─── Loading spinner (inside btn-fetch when fetching) ─── */
+    .spinner {
+      width: 14px; height: 14px;
+      border: 2px solid rgba(0,0,0,0.25); border-top-color: #000;
+      border-radius: 50%; animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ─── Success state ─── */
+    #success-state { display: none; }
+    #success-state.visible { display: block; animation: fadeUp 0.35s ease; }
+
+    .success-card {
+      text-align: center; padding: 48px 32px 40px;
+    }
+    .success-icon-wrap {
+      width: 72px; height: 72px; border-radius: 50%;
+      background: rgba(48,212,138,0.12);
+      border: 2px solid rgba(48,212,138,0.30);
+      display: flex; align-items: center; justify-content: center;
+      margin: 0 auto 24px;
+      animation: pulse-green 2s ease infinite;
+    }
+    .success-icon-wrap svg { width: 32px; height: 32px; color: var(--accent); }
+    @keyframes pulse-green {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(48,212,138,0.20); }
+      50%       { box-shadow: 0 0 0 12px rgba(48,212,138,0); }
+    }
+    .success-card h2 {
+      font-size: 24px; font-weight: 800; letter-spacing: -0.03em;
+      color: var(--fg); margin-bottom: 10px;
+    }
+    .success-card .lead {
+      font-size: 15px; color: var(--fg-muted); line-height: 1.6;
+      max-width: 440px; margin: 0 auto 32px;
+    }
+    .success-card .lead strong { color: var(--fg); font-weight: 500; }
+
+    .next-steps {
+      display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+      text-align: left; margin-bottom: 32px;
+    }
+    @media (max-width: 540px) { .next-steps { grid-template-columns: 1fr; } }
+
+    .next-step-item {
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 16px;
+    }
+    .next-step-num {
+      font-size: 11px; font-weight: 700; color: var(--accent);
+      text-transform: uppercase; letter-spacing: 0.1em; margin-bottom: 6px;
+    }
+    .next-step-title {
+      font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 4px;
+    }
+    .next-step-desc {
+      font-size: 11.5px; color: var(--fg-muted); line-height: 1.5;
+    }
+
+    .verify-callout {
+      background: rgba(48,212,138,0.06);
+      border: 1px solid rgba(48,212,138,0.18);
+      border-radius: var(--radius-lg);
+      padding: 16px 20px;
+      display: flex; align-items: flex-start; gap: 12px;
+      text-align: left;
+    }
+    .verify-callout svg { width: 16px; height: 16px; color: var(--accent); flex-shrink: 0; margin-top: 2px; }
+    .verify-callout p {
+      font-size: 12.5px; color: var(--fg-muted); line-height: 1.55;
+    }
+    .verify-callout p strong { color: var(--accent); font-weight: 600; }
+
+    .back-link {
+      display: inline-flex; align-items: center; gap: 6px;
+      font-size: 13px; color: var(--fg-subtle); text-decoration: none;
+      margin-top: 24px; transition: color 0.15s; cursor: pointer;
+      background: none; border: none; font-family: var(--font);
+    }
+    .back-link:hover { color: var(--fg-muted); }
+    .back-link svg { width: 14px; height: 14px; }
+
+    /* ─── Badge ─── */
+    .badge {
+      display: inline-flex; align-items: center; gap: 5px;
+      padding: 3px 9px; border-radius: 99px;
+      font-size: 11px; font-weight: 600;
+    }
+    .badge-green {
+      background: rgba(48,212,138,0.12);
+      border: 1px solid rgba(48,212,138,0.28);
+      color: var(--accent);
+    }
+    .badge-green svg { width: 10px; height: 10px; }
+
+    /* ─── Footer ─── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 32px 24px;
+      text-align: center;
+    }
+    footer p {
+      font-size: 12px; color: var(--fg-subtle);
+    }
+    footer a {
+      color: var(--fg-subtle); text-decoration: none; transition: color 0.15s;
+    }
+    footer a:hover { color: var(--fg-muted); }
+
+    /* ─── Util ─── */
+    .sr-only {
+      position: absolute; width: 1px; height: 1px;
+      overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap;
+    }
+    @media (max-width: 640px) {
+      .page-wrap { padding: 32px 18px 60px; }
+      .card { padding: 22px 18px; }
+    }
+  </style>
+</head>
+<body>
+
+<!-- ─── Nav ─── -->
+<nav aria-label="Site navigation">
+  <div class="nav-inner">
+    <a class="nav-logo" href="/">
+      <div class="nav-logo-icon" aria-hidden="true">
+        <svg width="104" height="104" viewBox="0 0 104 104" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect width="104" height="104" rx="19.5" fill="#0a0a0a"/>
+          <path d="M31.8914 92H14L41.2613 13H62.7773L90 92H72.1086L52.3278 31.0527H51.7108L31.8914 92ZM30.7732 60.9478H73.034V73.9858H30.7732V60.9478Z" fill="white"/>
+        </svg>
+      </div>
+      <span class="nav-logo-text">OpenAffiliate</span>
+    </a>
+    <nav class="nav-links" aria-label="Main">
+      <a href="/programs">Programs</a>
+      <a href="/explore">Explore</a>
+      <a href="/rankings">Rankings</a>
+      <a href="/submit" class="active" aria-current="page">Submit</a>
+      <a href="/docs">Docs</a>
+    </nav>
+    <a class="nav-gh" href="https://github.com/Affitor/open-affiliate" target="_blank" rel="noopener noreferrer" aria-label="GitHub">
+      <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+      <span>GitHub</span>
+    </a>
+  </div>
+</nav>
+
+<!-- ─── Trust strip ─── -->
+<div class="trust-strip" role="note" aria-label="Platform highlights">
+  <span>Free forever</span>
+  <span class="trust-sep">·</span>
+  <span>750+ programs listed</span>
+  <span class="trust-sep">·</span>
+  <span>Discovered by AI agents</span>
+  <span class="trust-sep">·</span>
+  <span>Verified-by-Stripe option</span>
+</div>
+
+<!-- ─── Main ─── -->
+<main>
+<div class="page-wrap">
+
+  <!-- Dev escape hatch -->
+  <a class="dev-link" href="https://github.com/Affitor/open-affiliate" target="_blank" rel="noopener noreferrer" title="For developers who prefer the YAML + PR flow">
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+    Developer? List via GitHub
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+  </a>
+
+  <!-- Form flow -->
+  <div id="form-flow">
+    <!-- Header -->
+    <div class="page-header">
+      <h1>List your affiliate program</h1>
+      <p>Takes about 2 minutes. No technical knowledge required — we handle everything behind the scenes.</p>
+    </div>
+
+    <!-- Stepper -->
+    <div class="stepper" role="list" aria-label="Steps">
+      <div class="step-item active" id="step-indicator-1" role="listitem">
+        <div class="step-circle" aria-label="Step 1">1</div>
+        <div class="step-label">Your product</div>
+      </div>
+      <div class="step-item" id="step-indicator-2" role="listitem">
+        <div class="step-circle" aria-label="Step 2">2</div>
+        <div class="step-label">Affiliate terms</div>
+      </div>
+      <div class="step-item" id="step-indicator-3" role="listitem">
+        <div class="step-circle" aria-label="Step 3">3</div>
+        <div class="step-label">Almost done</div>
+      </div>
+    </div>
+
+    <!-- ─── STEP 1: Your product ─── -->
+    <div class="step-panel visible" id="step-1">
+      <div class="card">
+        <h2 class="step-heading">Let's start with your product</h2>
+        <p class="step-sub">Paste your affiliate program page and we'll fill in most of this for you.</p>
+
+        <!-- Magic URL fetch -->
+        <div class="fetch-block" role="region" aria-label="Auto-fill from URL">
+          <div class="fetch-label">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+            Auto-fill from your website
+          </div>
+          <div class="fetch-row">
+            <input
+              class="fetch-input"
+              id="fetch-url"
+              type="url"
+              placeholder="yourproduct.com/affiliates"
+              aria-label="Your affiliate program URL"
+              autocomplete="url"
+            />
+            <button class="btn-fetch" id="btn-fetch" onclick="doFetch()">
+              <svg id="fetch-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+              <span id="fetch-btn-label">Fetch &amp; auto-fill</span>
+            </button>
+          </div>
+          <p class="fetch-hint">We scan your public page and prefill the form instantly.</p>
+          <div class="autofill-chip" id="autofill-chip" role="status" aria-live="polite">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+            Filled in 8 fields from your page — check them below and adjust anything.
+          </div>
+        </div>
+
+        <!-- Fields -->
+        <div class="field">
+          <label for="prog-name">Program name <span class="required" aria-label="required">*</span></label>
+          <input id="prog-name" type="text" placeholder="e.g. Lemon Squeezy" autocomplete="organization" aria-required="true" />
+        </div>
+
+        <div class="field-row">
+          <div class="field">
+            <label for="prog-website">Website <span class="required" aria-label="required">*</span></label>
+            <input id="prog-website" type="url" placeholder="lemonsqueezy.com" autocomplete="url" aria-required="true" />
+          </div>
+          <div class="field">
+            <label for="prog-signup">Affiliate sign-up page</label>
+            <input id="prog-signup" type="url" placeholder="lemonsqueezy.com/affiliates" autocomplete="url" />
+          </div>
+        </div>
+
+        <div class="field">
+          <label for="prog-category">What category fits best? <span class="required" aria-label="required">*</span></label>
+          <select id="prog-category" aria-required="true">
+            <option value="">Choose a category...</option>
+            <option>Developer Tools</option>
+            <option>E-commerce &amp; Payments</option>
+            <option>Marketing &amp; Growth</option>
+            <option>Email &amp; Communication</option>
+            <option>Analytics &amp; Data</option>
+            <option>Design &amp; Creative</option>
+            <option>Productivity &amp; Workspace</option>
+            <option>AI &amp; Automation</option>
+            <option>Sales &amp; CRM</option>
+            <option>HR &amp; Recruiting</option>
+            <option>Finance &amp; Accounting</option>
+            <option>Security &amp; Compliance</option>
+            <option>Infrastructure &amp; DevOps</option>
+            <option>Video &amp; Podcasting</option>
+            <option>Education &amp; Learning</option>
+            <option>Other SaaS</option>
+          </select>
+        </div>
+
+        <div class="field">
+          <label for="prog-pitch">One-line pitch — what problem does your product solve? <span class="required" aria-label="required">*</span></label>
+          <input id="prog-pitch" type="text" placeholder="e.g. The easiest way for creators to sell digital products" maxlength="120" aria-required="true" />
+          <p class="field-hint">Keep it to 1 sentence. This is what potential affiliates see first.</p>
+        </div>
+      </div>
+
+      <div class="btn-row">
+        <span></span>
+        <button class="btn-next" onclick="goToStep(2)" aria-label="Continue to affiliate terms">
+          Looks good, next
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- ─── STEP 2: Affiliate terms ─── -->
+    <div class="step-panel" id="step-2">
+      <div class="card">
+        <h2 class="step-heading">What do affiliates earn?</h2>
+        <p class="step-sub">These are the terms your affiliates will see. Plain and simple — no jargon.</p>
+
+        <!-- Commission -->
+        <div class="field">
+          <label>How do affiliates get paid? <span class="required" aria-label="required">*</span></label>
+          <div class="cookie-options" role="group" aria-label="Commission type">
+            <button class="cookie-opt selected" onclick="selectCommType(this, 'recurring')" type="button">% of every renewal</button>
+            <button class="cookie-opt" onclick="selectCommType(this, 'one-time')" type="button">% of first sale only</button>
+            <button class="cookie-opt" onclick="selectCommType(this, 'flat')" type="button">Fixed $ per sale</button>
+          </div>
+          <input type="hidden" id="comm-type" value="recurring" />
+        </div>
+
+        <div class="commission-grid">
+          <div class="field">
+            <label for="comm-rate">Affiliate earns <span class="required" aria-label="required">*</span></label>
+            <div class="input-with-suffix">
+              <input id="comm-rate" type="number" min="1" max="100" placeholder="30" aria-required="true" />
+              <span class="input-suffix" id="comm-suffix">%</span>
+            </div>
+            <p class="field-hint">e.g. 30% means they earn $30 on a $100 sale.</p>
+          </div>
+          <div class="field">
+            <label for="prog-trial">Free trial or money-back period</label>
+            <div class="input-with-suffix">
+              <input id="prog-trial" type="number" min="0" placeholder="14" />
+              <span class="input-suffix">days</span>
+            </div>
+            <p class="field-hint">Leave blank if none.</p>
+          </div>
+        </div>
+
+        <!-- Cookie window -->
+        <div class="field">
+          <label>How long is a referral tracked? <span class="required" aria-label="required">*</span></label>
+          <div class="cookie-picker">
+            <div class="cookie-options" role="group" aria-label="Referral tracking window">
+              <button class="cookie-opt" onclick="selectCookie(this, 7)" type="button">7 days</button>
+              <button class="cookie-opt" onclick="selectCookie(this, 30)" type="button">30 days</button>
+              <button class="cookie-opt selected" onclick="selectCookie(this, 60)" type="button">60 days</button>
+              <button class="cookie-opt" onclick="selectCookie(this, 90)" type="button">90 days</button>
+              <button class="cookie-opt" onclick="selectCookie(this, 0)" type="button">Lifetime</button>
+            </div>
+            <div class="cookie-custom" id="cookie-custom" style="display:none;">
+              <input type="number" id="cookie-custom-val" placeholder="45" min="1" max="365" aria-label="Custom cookie days" />
+              <span>days</span>
+            </div>
+          </div>
+          <input type="hidden" id="cookie-days" value="60" />
+          <p class="field-hint" style="margin-top:8px;">If someone clicks an affiliate's link today, they get credit if that person buys within this window.</p>
+        </div>
+
+        <!-- Advanced accordion -->
+        <div style="margin-top: 8px; border-top: 1px solid var(--border); padding-top: 4px;">
+          <button
+            class="accordion-toggle"
+            id="adv-toggle"
+            onclick="toggleAdvanced()"
+            type="button"
+            aria-expanded="false"
+            aria-controls="advanced-fields"
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="6 9 12 15 18 9"/></svg>
+            Add more details (optional) — payout method, minimum, restrictions
+          </button>
+          <div class="accordion-body" id="advanced-fields" role="region" aria-label="Optional details">
+            <div class="accordion-divider"></div>
+
+            <div class="commission-grid">
+              <div class="field">
+                <label for="payout-min">Minimum payout amount</label>
+                <div class="input-with-suffix">
+                  <input id="payout-min" type="number" min="0" placeholder="50" />
+                  <span class="input-suffix">USD</span>
+                </div>
+                <p class="field-hint">The minimum balance before we send a payment.</p>
+              </div>
+              <div class="field">
+                <label for="payout-freq">How often are affiliates paid?</label>
+                <select id="payout-freq">
+                  <option value="monthly">Monthly</option>
+                  <option value="bi-weekly">Every two weeks</option>
+                  <option value="net-30">Net 30</option>
+                  <option value="net-60">Net 60</option>
+                </select>
+              </div>
+            </div>
+
+            <div class="field">
+              <label for="payout-method">How are affiliates paid?</label>
+              <select id="payout-method">
+                <option value="">Choose...</option>
+                <option>PayPal</option>
+                <option>Stripe</option>
+                <option>Bank transfer (ACH / SEPA)</option>
+                <option>Wise</option>
+                <option>Store credit</option>
+                <option>Other</option>
+              </select>
+            </div>
+
+            <div class="field">
+              <label for="restrictions">Any restrictions? <span style="font-weight:400;color:var(--fg-subtle)">(optional)</span></label>
+              <textarea id="restrictions" rows="2" placeholder="e.g. Open to US/EU only, no coupon sites, no paid ads on brand name"></textarea>
+              <p class="field-hint">Leave blank if there are none. Affiliates appreciate knowing upfront.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="btn-row">
+        <button class="btn-back" onclick="goToStep(1)" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+          Back
+        </button>
+        <button class="btn-next" onclick="goToStep(3)" aria-label="Continue to final step">
+          Almost done
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+        </button>
+      </div>
+    </div>
+
+    <!-- ─── STEP 3: Almost done ─── -->
+    <div class="step-panel" id="step-3">
+      <div class="card">
+        <!-- Email magic-link -->
+        <div class="email-hero" role="region" aria-label="Email verification">
+          <div class="icon-ring" aria-hidden="true">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg>
+          </div>
+          <h3>One last thing — your email</h3>
+          <p>We'll send you a magic link so you can edit your listing, respond to the review, and claim your <span class="badge badge-green"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>Verified</span> badge later. No password needed.</p>
+        </div>
+
+        <div class="field">
+          <label for="sub-email">Your work email <span class="required" aria-label="required">*</span></label>
+          <input id="sub-email" type="email" placeholder="you@yourcompany.com" autocomplete="email" aria-required="true" />
+          <p class="field-hint">We only use this to send your edit link and listing status. No marketing.</p>
+        </div>
+
+        <label class="checkbox-row">
+          <input type="checkbox" id="works-here" />
+          <span>I work at this company — <strong>request a Verified badge</strong> once my listing is live.</span>
+        </label>
+
+        <!-- Review summary -->
+        <div class="review-summary" role="region" aria-label="Submission summary">
+          <h4>Your submission at a glance</h4>
+          <div class="review-row">
+            <span class="review-key">Program</span>
+            <span class="review-val" id="rv-name">Lemon Squeezy</span>
+          </div>
+          <div class="review-row">
+            <span class="review-key">Website</span>
+            <span class="review-val" id="rv-website">lemonsqueezy.com</span>
+          </div>
+          <div class="review-row">
+            <span class="review-key">Category</span>
+            <span class="review-val" id="rv-category">E-commerce &amp; Payments</span>
+          </div>
+          <div class="review-row">
+            <span class="review-key">Affiliates earn</span>
+            <span class="review-val" id="rv-commission">30% of every renewal</span>
+          </div>
+          <div class="review-row">
+            <span class="review-key">Referral window</span>
+            <span class="review-val" id="rv-cookie">60 days</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="btn-row">
+        <button class="btn-back" onclick="goToStep(2)" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+          Back
+        </button>
+        <button class="btn-submit" onclick="submitForm()" type="button">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M12 19V5M5 12l7-7 7 7"/></svg>
+          Submit listing
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- ─── SUCCESS STATE ─── -->
+  <div id="success-state" role="alert" aria-live="polite">
+    <div class="card success-card">
+      <div class="success-icon-wrap" aria-hidden="true">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>
+      </div>
+      <h2>Submitted!</h2>
+      <p class="lead">
+        We're reviewing <strong id="success-name">Lemon Squeezy</strong>. It's usually live within minutes — often within the hour.
+        <br /><br />
+        Check your inbox at <strong id="success-email">you@yourcompany.com</strong> — we'll send a magic link to edit or claim your listing.
+      </p>
+
+      <div class="next-steps" aria-label="What happens next">
+        <div class="next-step-item">
+          <div class="next-step-num">Step 1</div>
+          <div class="next-step-title">We review</div>
+          <div class="next-step-desc">A quick check that everything looks accurate. Usually under an hour.</div>
+        </div>
+        <div class="next-step-item">
+          <div class="next-step-num">Step 2</div>
+          <div class="next-step-title">Goes live</div>
+          <div class="next-step-desc">Your program appears in search, AI agent queries, and the registry.</div>
+        </div>
+        <div class="next-step-item">
+          <div class="next-step-num">Step 3</div>
+          <div class="next-step-title">Claim &amp; verify</div>
+          <div class="next-step-desc">Use your email link to edit details and unlock the Verified badge.</div>
+        </div>
+      </div>
+
+      <div class="verify-callout">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>
+        <p>
+          The <strong>Verified badge</strong> signals to affiliates that your program is actively managed — it appears prominently in search results and increases sign-up rates. You can claim it from your listing once it's live.
+        </p>
+      </div>
+
+      <button class="back-link" onclick="resetForm()" aria-label="Submit another program">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+        Submit another program
+      </button>
+    </div>
+  </div>
+
+</div>
+</main>
+
+<!-- ─── Footer ─── -->
+<footer>
+  <p>
+    OpenAffiliate — open source, community-driven.
+    &nbsp;·&nbsp;
+    <a href="/docs">Docs</a>
+    &nbsp;·&nbsp;
+    <a href="https://github.com/Affitor/open-affiliate" target="_blank" rel="noopener noreferrer">GitHub</a>
+    &nbsp;·&nbsp;
+    <a href="/feedback">Feedback</a>
+  </p>
+</footer>
+
+<script>
+  /* ─── State ─── */
+  let currentStep = 1;
+  let cookieVal = 60;
+  let commType = 'recurring';
+
+  /* ─── Step navigation ─── */
+  function goToStep(n) {
+    document.getElementById('step-' + currentStep).classList.remove('visible');
+    document.getElementById('step-indicator-' + currentStep).classList.remove('active');
+    if (n > currentStep) {
+      document.getElementById('step-indicator-' + currentStep).classList.add('done');
+      document.getElementById('step-indicator-' + currentStep).querySelector('.step-circle').innerHTML =
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3" style="width:12px;height:12px" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>';
+    } else {
+      document.getElementById('step-indicator-' + (currentStep)).classList.remove('done');
+      document.getElementById('step-indicator-' + (currentStep)).querySelector('.step-circle').textContent = currentStep;
+    }
+    currentStep = n;
+    document.getElementById('step-' + n).classList.add('visible');
+    document.getElementById('step-indicator-' + n).classList.add('active');
+    if (n === 3) { buildSummary(); }
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  /* ─── Build summary for step 3 ─── */
+  function buildSummary() {
+    var name = document.getElementById('prog-name').value || 'Your program';
+    var website = document.getElementById('prog-website').value || '—';
+    var category = document.getElementById('prog-category').value || '—';
+    var rate = document.getElementById('comm-rate').value;
+    var suffix = document.getElementById('comm-suffix').textContent;
+    var typeLabels = { recurring: 'of every renewal', 'one-time': 'of first sale only', flat: 'per sale' };
+    var commLabel = rate ? (rate + suffix + ' ' + (typeLabels[commType] || '')) : '—';
+    var cookieLabel = cookieVal === 0 ? 'Lifetime' : cookieVal + ' days';
+
+    document.getElementById('rv-name').textContent = name;
+    document.getElementById('rv-website').textContent = website.replace(/^https?:\/\//, '');
+    document.getElementById('rv-category').textContent = category;
+    document.getElementById('rv-commission').textContent = commLabel;
+    document.getElementById('rv-cookie').textContent = cookieLabel;
+  }
+
+  /* ─── Cookie selector ─── */
+  function selectCookie(btn, val) {
+    document.querySelectorAll('.cookie-picker .cookie-opt').forEach(function(b) {
+      b.classList.remove('selected');
+    });
+    btn.classList.add('selected');
+    cookieVal = val;
+    document.getElementById('cookie-days').value = val;
+    var custom = document.getElementById('cookie-custom');
+    if (val === -1) {
+      custom.style.display = 'flex';
+      document.getElementById('cookie-custom-val').focus();
+    } else {
+      custom.style.display = 'none';
+    }
+  }
+
+  /* ─── Commission type selector ─── */
+  function selectCommType(btn, type) {
+    document.querySelectorAll('.field .cookie-options .cookie-opt').forEach(function(b) {
+      b.classList.remove('selected');
+    });
+    btn.classList.add('selected');
+    commType = type;
+    document.getElementById('comm-type').value = type;
+    var suffix = document.getElementById('comm-suffix');
+    if (type === 'flat') { suffix.textContent = 'USD'; }
+    else { suffix.textContent = '%'; }
+  }
+
+  /* ─── Advanced accordion ─── */
+  function toggleAdvanced() {
+    var toggle = document.getElementById('adv-toggle');
+    var body = document.getElementById('advanced-fields');
+    var isOpen = body.classList.contains('open');
+    toggle.classList.toggle('open', !isOpen);
+    toggle.setAttribute('aria-expanded', String(!isOpen));
+    body.classList.toggle('open', !isOpen);
+  }
+
+  /* ─── Magic auto-fill (simulated) ─── */
+  function doFetch() {
+    var urlVal = document.getElementById('fetch-url').value.trim();
+    if (!urlVal) {
+      document.getElementById('fetch-url').focus();
+      return;
+    }
+    var btn = document.getElementById('btn-fetch');
+    var icon = document.getElementById('fetch-icon');
+    var label = document.getElementById('fetch-btn-label');
+
+    // Show loading state
+    btn.disabled = true;
+    icon.outerHTML = '<div class="spinner" id="fetch-icon" aria-hidden="true"></div>';
+    label.textContent = 'Fetching...';
+
+    // Simulate network delay + auto-fill
+    setTimeout(function() {
+      // Restore button
+      document.getElementById('fetch-icon').outerHTML =
+        '<svg id="fetch-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="width:14px;height:14px" aria-hidden="true"><path d="M20 6L9 17l-5-5"/></svg>';
+      document.getElementById('fetch-btn-label').textContent = 'Re-fetch';
+      btn.disabled = false;
+
+      // Simulate prefill based on URL
+      var clean = urlVal.replace(/^https?:\/\//, '').split('/')[0];
+      var demo = getDemoData(clean);
+      document.getElementById('prog-name').value = demo.name;
+      document.getElementById('prog-website').value = demo.website;
+      document.getElementById('prog-signup').value = demo.signup;
+      document.getElementById('prog-pitch').value = demo.pitch;
+      // Category
+      var catSelect = document.getElementById('prog-category');
+      for (var i = 0; i < catSelect.options.length; i++) {
+        if (catSelect.options[i].value === demo.category) {
+          catSelect.value = demo.category;
+          break;
+        }
+      }
+
+      // Show chip
+      var chip = document.getElementById('autofill-chip');
+      chip.classList.add('visible');
+    }, 1500);
+  }
+
+  function getDemoData(domain) {
+    // Demo data for mockup
+    return {
+      name: 'Lemon Squeezy',
+      website: 'lemonsqueezy.com',
+      signup: 'lemonsqueezy.com/affiliates',
+      category: 'E-commerce & Payments',
+      pitch: 'The easiest way for creators and SaaS founders to sell digital products and subscriptions'
+    };
+  }
+
+  /* ─── Submit ─── */
+  function submitForm() {
+    var email = document.getElementById('sub-email').value.trim();
+    if (!email) {
+      document.getElementById('sub-email').focus();
+      return;
+    }
+    var name = document.getElementById('prog-name').value || 'Your program';
+    document.getElementById('success-name').textContent = name;
+    document.getElementById('success-email').textContent = email;
+    document.getElementById('form-flow').style.display = 'none';
+    document.getElementById('success-state').classList.add('visible');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  /* ─── Reset (submit another) ─── */
+  function resetForm() {
+    document.getElementById('success-state').classList.remove('visible');
+    document.getElementById('form-flow').style.display = 'block';
+    // Reset steps
+    for (var i = 1; i <= 3; i++) {
+      var ind = document.getElementById('step-indicator-' + i);
+      ind.classList.remove('active', 'done');
+      ind.querySelector('.step-circle').textContent = i;
+    }
+    currentStep = 1;
+    document.getElementById('step-1').classList.add('visible');
+    document.getElementById('step-2').classList.remove('visible');
+    document.getElementById('step-3').classList.remove('visible');
+    document.getElementById('step-indicator-1').classList.add('active');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+</script>
+</body>
+</html>

--- a/docs/mockups/submit-v3-split-preview.html
+++ b/docs/mockups/submit-v3-split-preview.html
@@ -1,0 +1,1658 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>List Your Program — OpenAffiliate</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    /* ── Design tokens (dark mode) ─────────────────────────────────────── */
+    :root {
+      --bg:            #1a1a18;          /* oklch(0.13 0.005 75) approx */
+      --bg-card:       #1f1f1d;          /* oklch(0.17 0.005 75) approx */
+      --bg-muted:      #252523;          /* oklch(0.22 0.005 75) approx */
+      --fg:            #fafafa;          /* oklch(0.985 0 0) */
+      --fg-muted:      #a3a3a3;          /* oklch(0.708 0 0) */
+      --fg-subtle:     #737373;
+      --border:        rgba(255,255,255,0.10);
+      --border-soft:   rgba(255,255,255,0.06);
+      --input-bg:      rgba(255,255,255,0.08);
+      --input-border:  rgba(255,255,255,0.12);
+      --radius:        0.625rem;
+      --radius-lg:     0.875rem;
+      --radius-xl:     1.125rem;
+      --accent:        #34d399;          /* emerald-400 */
+      --accent-dim:    rgba(52,211,153,0.12);
+      --accent-border: rgba(52,211,153,0.28);
+      --accent-dark:   #059669;
+      --blue:          #60a5fa;
+      --blue-dim:      rgba(96,165,250,0.12);
+      --font: 'Geist', -apple-system, BlinkMacSystemFont, sans-serif;
+      --mono: 'Geist Mono', ui-monospace, monospace;
+    }
+
+    html { color-scheme: dark; scroll-behavior: smooth; }
+
+    body {
+      font-family: var(--font);
+      background: var(--bg);
+      color: var(--fg);
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      font-size: 14px;
+      line-height: 1.5;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Dot grid background */
+    .dot-grid {
+      background-image: radial-gradient(circle, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 24px 24px;
+    }
+
+    /* ── Nav ───────────────────────────────────────────────────────────── */
+    nav {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      border-bottom: 1px solid var(--border-soft);
+      background: rgba(26,26,24,0.85);
+      backdrop-filter: blur(12px);
+    }
+    .nav-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+      height: 52px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .nav-logo {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      text-decoration: none;
+      color: var(--fg);
+      font-weight: 600;
+      font-size: 14px;
+      letter-spacing: -0.01em;
+    }
+    .nav-logo-icon {
+      width: 22px;
+      height: 22px;
+      border-radius: 6px;
+      background: linear-gradient(135deg, var(--accent) 0%, #10b981 100%);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 11px;
+      color: #0a1a12;
+      flex-shrink: 0;
+    }
+    .nav-links {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .nav-link {
+      font-size: 13px;
+      color: var(--fg-muted);
+      text-decoration: none;
+      padding: 5px 10px;
+      border-radius: 6px;
+      transition: color 0.15s, background 0.15s;
+    }
+    .nav-link:hover { color: var(--fg); background: var(--bg-muted); }
+    .nav-link.active { color: var(--fg); background: var(--bg-muted); }
+    .nav-right { display: flex; align-items: center; gap: 8px; }
+    .btn-sm {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 5px 12px;
+      border-radius: var(--radius);
+      cursor: pointer;
+      transition: all 0.15s;
+      text-decoration: none;
+      border: 1px solid var(--border);
+      background: var(--bg-muted);
+      color: var(--fg-muted);
+    }
+    .btn-sm:hover { color: var(--fg); border-color: rgba(255,255,255,0.18); }
+
+    /* ── Page shell ────────────────────────────────────────────────────── */
+    main { flex: 1; padding-bottom: 80px; }
+
+    /* ── Page header ───────────────────────────────────────────────────── */
+    .page-header {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 40px 24px 28px;
+    }
+    .dev-escape {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 11.5px;
+      color: var(--fg-subtle);
+      text-decoration: none;
+      padding: 4px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border-soft);
+      background: var(--bg-muted);
+      margin-bottom: 20px;
+      transition: color 0.15s, border-color 0.15s;
+    }
+    .dev-escape:hover { color: var(--fg-muted); border-color: var(--border); }
+    .dev-escape svg { opacity: 0.5; }
+
+    .page-title {
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      line-height: 1.2;
+      margin-bottom: 8px;
+    }
+    .page-subtitle {
+      font-size: 14px;
+      color: var(--fg-muted);
+      max-width: 500px;
+      line-height: 1.6;
+    }
+
+    /* ── Trust strip ───────────────────────────────────────────────────── */
+    .trust-strip {
+      display: flex;
+      align-items: center;
+      gap: 20px;
+      flex-wrap: wrap;
+      margin-top: 16px;
+    }
+    .trust-item {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 12px;
+      color: var(--fg-subtle);
+    }
+    .trust-item svg { color: var(--accent); flex-shrink: 0; }
+    .trust-sep { color: var(--border); }
+
+    /* ── Two-column layout ──────────────────────────────────────────────── */
+    .split-layout {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 0 24px;
+      display: grid;
+      grid-template-columns: 1fr 400px;
+      gap: 24px;
+      align-items: start;
+    }
+    @media (max-width: 900px) {
+      .split-layout { grid-template-columns: 1fr; }
+      .preview-col { display: none; }
+    }
+
+    /* ── Form column ────────────────────────────────────────────────────── */
+    .form-col { display: flex; flex-direction: column; gap: 16px; }
+
+    /* ── Magic URL step ─────────────────────────────────────────────────── */
+    .magic-card {
+      background: var(--bg-card);
+      border: 1px solid var(--accent-border);
+      border-radius: var(--radius-xl);
+      padding: 20px;
+      position: relative;
+      overflow: hidden;
+    }
+    .magic-card::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(ellipse 60% 40% at 100% 0%, rgba(52,211,153,0.05) 0%, transparent 70%);
+      pointer-events: none;
+    }
+    .magic-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 10px;
+    }
+    .magic-label .step-num {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent-border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 10px;
+      font-weight: 700;
+      color: var(--accent);
+    }
+    .magic-heading {
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      margin-bottom: 4px;
+    }
+    .magic-subhead {
+      font-size: 13px;
+      color: var(--fg-muted);
+      margin-bottom: 14px;
+    }
+    .url-row {
+      display: flex;
+      gap: 8px;
+    }
+    .url-row input {
+      flex: 1;
+    }
+    .fetch-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--font);
+      font-size: 13px;
+      font-weight: 600;
+      padding: 0 16px;
+      border-radius: var(--radius);
+      background: var(--accent);
+      color: #0a1a12;
+      border: none;
+      cursor: pointer;
+      white-space: nowrap;
+      height: 38px;
+      transition: background 0.15s, opacity 0.15s;
+      flex-shrink: 0;
+    }
+    .fetch-btn:hover { background: #6ee7b7; }
+    .fetch-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+    /* Fetching state */
+    .fetch-status {
+      display: none;
+      align-items: center;
+      gap: 8px;
+      font-size: 12px;
+      color: var(--fg-muted);
+      margin-top: 10px;
+    }
+    .fetch-status.visible { display: flex; }
+    .fetch-status.success { color: var(--accent); }
+    .spinner {
+      width: 14px;
+      height: 14px;
+      border: 2px solid rgba(255,255,255,0.15);
+      border-top-color: var(--accent);
+      border-radius: 50%;
+      animation: spin 0.7s linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+
+    /* ── Form section card ──────────────────────────────────────────────── */
+    .form-section {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      overflow: hidden;
+    }
+    .form-section-header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      padding: 16px 20px 14px;
+      border-bottom: 1px solid var(--border-soft);
+    }
+    .section-step {
+      width: 22px;
+      height: 22px;
+      border-radius: 50%;
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 11px;
+      font-weight: 600;
+      color: var(--fg-muted);
+      flex-shrink: 0;
+    }
+    .section-step.active {
+      background: var(--accent-dim);
+      border-color: var(--accent-border);
+      color: var(--accent);
+    }
+    .form-section-title {
+      font-size: 13px;
+      font-weight: 600;
+      letter-spacing: -0.005em;
+    }
+    .form-section-body {
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+
+    /* ── Form fields ────────────────────────────────────────────────────── */
+    .field-group {
+      display: grid;
+      gap: 12px;
+    }
+    .field-group.cols-2 { grid-template-columns: 1fr 1fr; }
+    .field-group.cols-3 { grid-template-columns: 1fr 1fr 1fr; }
+    @media (max-width: 600px) {
+      .field-group.cols-2 { grid-template-columns: 1fr; }
+      .field-group.cols-3 { grid-template-columns: 1fr; }
+    }
+
+    .field { display: flex; flex-direction: column; gap: 5px; }
+    label {
+      font-size: 12px;
+      font-weight: 500;
+      color: var(--fg-muted);
+      letter-spacing: 0.01em;
+    }
+    label .hint {
+      font-weight: 400;
+      color: var(--fg-subtle);
+      margin-left: 4px;
+    }
+    input[type="text"],
+    input[type="email"],
+    input[type="url"],
+    input[type="number"],
+    select,
+    textarea {
+      font-family: var(--font);
+      font-size: 13.5px;
+      color: var(--fg);
+      background: var(--input-bg);
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius);
+      padding: 8px 12px;
+      width: 100%;
+      outline: none;
+      transition: border-color 0.15s, box-shadow 0.15s, background 0.15s;
+      appearance: none;
+      -webkit-appearance: none;
+    }
+    input::placeholder, textarea::placeholder { color: var(--fg-subtle); }
+    input:focus, select:focus, textarea:focus {
+      border-color: rgba(52,211,153,0.4);
+      box-shadow: 0 0 0 3px rgba(52,211,153,0.08);
+      background: rgba(255,255,255,0.07);
+    }
+    textarea { resize: none; }
+
+    /* Select arrow */
+    .select-wrap { position: relative; }
+    .select-wrap select { padding-right: 32px; cursor: pointer; }
+    .select-wrap::after {
+      content: '';
+      position: absolute;
+      right: 12px;
+      top: 50%;
+      transform: translateY(-50%);
+      width: 0;
+      height: 0;
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+      border-top: 5px solid var(--fg-subtle);
+      pointer-events: none;
+    }
+    select option { background: #1f1f1d; color: var(--fg); }
+
+    /* Inline prefix/suffix */
+    .input-prefix {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius);
+      background: var(--input-bg);
+      overflow: hidden;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .input-prefix:focus-within {
+      border-color: rgba(52,211,153,0.4);
+      box-shadow: 0 0 0 3px rgba(52,211,153,0.08);
+    }
+    .input-prefix .prefix-text {
+      padding: 8px 10px 8px 12px;
+      font-size: 13px;
+      color: var(--fg-subtle);
+      border-right: 1px solid var(--border-soft);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+    .input-prefix input {
+      border: none;
+      border-radius: 0;
+      background: transparent;
+      flex: 1;
+      box-shadow: none;
+    }
+    .input-prefix input:focus {
+      border-color: transparent;
+      box-shadow: none;
+    }
+
+    /* Suffix for % */
+    .input-suffix {
+      display: flex;
+      align-items: center;
+      border: 1px solid var(--input-border);
+      border-radius: var(--radius);
+      background: var(--input-bg);
+      overflow: hidden;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .input-suffix:focus-within {
+      border-color: rgba(52,211,153,0.4);
+      box-shadow: 0 0 0 3px rgba(52,211,153,0.08);
+    }
+    .input-suffix input {
+      border: none;
+      border-radius: 0;
+      background: transparent;
+      flex: 1;
+      min-width: 0;
+      box-shadow: none;
+    }
+    .input-suffix input:focus {
+      border-color: transparent;
+      box-shadow: none;
+    }
+    .input-suffix .suffix-text {
+      padding: 8px 12px 8px 8px;
+      font-size: 13px;
+      color: var(--fg-subtle);
+      border-left: 1px solid var(--border-soft);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* Commission type pills */
+    .type-pills {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+    }
+    .type-pill {
+      font-family: var(--font);
+      font-size: 12px;
+      font-weight: 500;
+      padding: 5px 12px;
+      border-radius: 20px;
+      border: 1px solid var(--border);
+      background: transparent;
+      color: var(--fg-muted);
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+    .type-pill:hover { border-color: rgba(255,255,255,0.2); color: var(--fg); }
+    .type-pill.selected {
+      background: var(--accent-dim);
+      border-color: var(--accent-border);
+      color: var(--accent);
+    }
+
+    /* ── Advanced toggle ────────────────────────────────────────────────── */
+    .advanced-toggle {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 12.5px;
+      color: var(--fg-muted);
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-family: var(--font);
+      padding: 10px 20px;
+      border-top: 1px solid var(--border-soft);
+      width: 100%;
+      text-align: left;
+      transition: color 0.15s;
+    }
+    .advanced-toggle:hover { color: var(--fg); }
+    .advanced-toggle svg { transition: transform 0.2s; }
+    .advanced-toggle.open svg { transform: rotate(180deg); }
+    .advanced-body {
+      display: none;
+      padding: 16px 20px 20px;
+      border-top: 1px solid var(--border-soft);
+      flex-direction: column;
+      gap: 14px;
+    }
+    .advanced-body.open { display: flex; }
+
+    /* ── Identity section ───────────────────────────────────────────────── */
+    .identity-section {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .identity-head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .identity-head svg { color: var(--accent); }
+
+    .checkbox-row {
+      display: flex;
+      align-items: flex-start;
+      gap: 10px;
+      cursor: pointer;
+    }
+    .checkbox-row input[type="checkbox"] {
+      width: 15px;
+      height: 15px;
+      min-width: 15px;
+      margin-top: 1px;
+      border: 1px solid var(--input-border);
+      background: var(--input-bg);
+      border-radius: 4px;
+      cursor: pointer;
+      accent-color: var(--accent);
+    }
+    .checkbox-label {
+      font-size: 13px;
+      color: var(--fg-muted);
+      line-height: 1.5;
+    }
+    .checkbox-label strong { color: var(--fg); }
+
+    /* ── Submit row ─────────────────────────────────────────────────────── */
+    .submit-row {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .btn-primary {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      font-family: var(--font);
+      font-size: 14px;
+      font-weight: 600;
+      padding: 12px 24px;
+      border-radius: var(--radius-lg);
+      background: var(--fg);
+      color: var(--bg);
+      border: none;
+      cursor: pointer;
+      width: 100%;
+      transition: background 0.15s, transform 0.1s;
+      letter-spacing: -0.01em;
+    }
+    .btn-primary:hover { background: rgba(250,250,250,0.9); }
+    .btn-primary:active { transform: scale(0.99); }
+    .btn-primary:disabled { opacity: 0.4; cursor: not-allowed; }
+    .submit-note {
+      font-size: 11.5px;
+      color: var(--fg-subtle);
+      text-align: center;
+      line-height: 1.6;
+    }
+    .submit-note a { color: var(--fg-muted); text-decoration: underline; text-decoration-color: rgba(255,255,255,0.15); }
+
+    /* ── Preview column ─────────────────────────────────────────────────── */
+    .preview-col {
+      position: sticky;
+      top: 72px;
+    }
+    .preview-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .preview-label {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--fg-subtle);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+    .preview-label::before, .preview-label::after {
+      content: '';
+      flex: 1;
+      height: 1px;
+      background: var(--border-soft);
+    }
+
+    /* Live indicator */
+    .live-dot {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      font-size: 11px;
+      color: var(--accent);
+      font-weight: 500;
+    }
+    .live-dot::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 0 rgba(52,211,153,0.4);
+      animation: pulse 2s infinite;
+    }
+    @keyframes pulse {
+      0% { box-shadow: 0 0 0 0 rgba(52,211,153,0.4); }
+      70% { box-shadow: 0 0 0 6px rgba(52,211,153,0); }
+      100% { box-shadow: 0 0 0 0 rgba(52,211,153,0); }
+    }
+
+    /* Program card preview */
+    .program-card {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 18px;
+      transition: border-color 0.3s, box-shadow 0.3s;
+    }
+    .program-card.has-content {
+      border-color: rgba(52,211,153,0.15);
+      box-shadow: 0 0 20px rgba(52,211,153,0.04);
+    }
+    .card-top {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      margin-bottom: 12px;
+    }
+    .card-logo {
+      width: 40px;
+      height: 40px;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      background: var(--bg-muted);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 16px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      color: var(--fg-subtle);
+      flex-shrink: 0;
+      overflow: hidden;
+      transition: background 0.2s, color 0.2s;
+    }
+    .card-logo.filled {
+      background: linear-gradient(135deg, #1a3a2a 0%, #0d2118 100%);
+      color: var(--accent);
+      border-color: rgba(52,211,153,0.15);
+    }
+    .card-meta { flex: 1; min-width: 0; }
+    .card-name {
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+      color: var(--fg);
+      margin-bottom: 2px;
+      transition: all 0.15s;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .card-name.empty { color: var(--fg-subtle); font-weight: 400; font-style: italic; }
+    .card-category {
+      font-size: 11px;
+      color: var(--fg-subtle);
+    }
+    .card-badges {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      font-weight: 500;
+      padding: 3px 8px;
+      border-radius: 20px;
+      line-height: 1;
+    }
+    .badge-commission {
+      background: rgba(52,211,153,0.12);
+      color: var(--accent);
+      border: 1px solid rgba(52,211,153,0.2);
+    }
+    .badge-cookie {
+      background: rgba(255,255,255,0.06);
+      color: var(--fg-muted);
+      border: 1px solid var(--border);
+    }
+    .badge-type {
+      background: rgba(255,255,255,0.06);
+      color: var(--fg-muted);
+      border: 1px solid var(--border);
+    }
+    .badge-verified {
+      background: rgba(52,211,153,0.1);
+      color: var(--accent);
+      border: 1px solid rgba(52,211,153,0.2);
+    }
+    .card-description {
+      font-size: 12.5px;
+      color: var(--fg-muted);
+      line-height: 1.55;
+      margin-bottom: 14px;
+      min-height: 36px;
+    }
+    .card-description.empty { color: var(--fg-subtle); font-style: italic; }
+    .card-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding-top: 12px;
+      border-top: 1px solid var(--border-soft);
+    }
+    .card-cta {
+      font-size: 12px;
+      font-weight: 600;
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+    .card-score {
+      font-size: 11px;
+      color: var(--fg-subtle);
+      display: flex;
+      align-items: center;
+      gap: 4px;
+    }
+
+    /* Preview context labels */
+    .preview-ctx {
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 14px 16px;
+      font-size: 12px;
+      color: var(--fg-muted);
+      line-height: 1.6;
+    }
+    .preview-ctx strong { color: var(--fg); font-weight: 600; }
+    .preview-ctx ul {
+      list-style: none;
+      margin-top: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 5px;
+    }
+    .preview-ctx ul li {
+      display: flex;
+      align-items: flex-start;
+      gap: 7px;
+    }
+    .preview-ctx ul li::before {
+      content: '↳';
+      color: var(--accent);
+      flex-shrink: 0;
+      font-size: 11px;
+      margin-top: 1px;
+    }
+
+    /* ── Success state ──────────────────────────────────────────────────── */
+    #success-state { display: none; }
+    #success-state.visible { display: block; }
+    #form-state.hidden { display: none !important; }
+
+    .success-wrap {
+      max-width: 600px;
+      margin: 0 auto;
+      padding: 0 24px 80px;
+      text-align: center;
+    }
+    .success-icon {
+      width: 72px;
+      height: 72px;
+      border-radius: 50%;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent-border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 24px;
+    }
+    .success-icon svg { color: var(--accent); }
+    .success-title {
+      font-size: 28px;
+      font-weight: 700;
+      letter-spacing: -0.03em;
+      margin-bottom: 12px;
+      line-height: 1.2;
+    }
+    .success-subtitle {
+      font-size: 15px;
+      color: var(--fg-muted);
+      line-height: 1.6;
+      margin-bottom: 32px;
+      max-width: 420px;
+      margin-left: auto;
+      margin-right: auto;
+    }
+    .success-email-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      border-radius: 40px;
+      padding: 8px 16px;
+      font-size: 13px;
+      color: var(--fg);
+      margin-bottom: 36px;
+    }
+    .success-email-badge svg { color: var(--accent); }
+
+    .what-next {
+      background: var(--bg-card);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-xl);
+      padding: 24px;
+      text-align: left;
+      margin-bottom: 24px;
+    }
+    .what-next-title {
+      font-size: 12px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--fg-subtle);
+      margin-bottom: 16px;
+    }
+    .next-steps {
+      display: flex;
+      flex-direction: column;
+      gap: 0;
+    }
+    .next-step {
+      display: flex;
+      align-items: flex-start;
+      gap: 14px;
+      padding: 14px 0;
+      border-bottom: 1px solid var(--border-soft);
+    }
+    .next-step:last-child { border-bottom: none; }
+    .next-step-num {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--bg-muted);
+      border: 1px solid var(--border);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      font-weight: 700;
+      color: var(--fg-muted);
+      flex-shrink: 0;
+    }
+    .next-step.done .next-step-num {
+      background: var(--accent-dim);
+      border-color: var(--accent-border);
+      color: var(--accent);
+    }
+    .next-step-body { flex: 1; }
+    .next-step-title {
+      font-size: 13.5px;
+      font-weight: 600;
+      margin-bottom: 3px;
+    }
+    .next-step-desc {
+      font-size: 12.5px;
+      color: var(--fg-muted);
+      line-height: 1.5;
+    }
+    .verified-badge-inline {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      background: var(--accent-dim);
+      border: 1px solid var(--accent-border);
+      color: var(--accent);
+      border-radius: 20px;
+      padding: 2px 8px;
+      margin-left: 4px;
+    }
+
+    .success-actions {
+      display: flex;
+      gap: 10px;
+      justify-content: center;
+      flex-wrap: wrap;
+    }
+    .btn-outline {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-family: var(--font);
+      font-size: 13px;
+      font-weight: 500;
+      padding: 9px 18px;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      background: var(--bg-muted);
+      color: var(--fg-muted);
+      cursor: pointer;
+      text-decoration: none;
+      transition: all 0.15s;
+    }
+    .btn-outline:hover { color: var(--fg); border-color: rgba(255,255,255,0.2); }
+
+    /* ── Footer ─────────────────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border-soft);
+      padding: 32px 24px;
+    }
+    .footer-inner {
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      flex-wrap: wrap;
+    }
+    .footer-logo {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 13px;
+      color: var(--fg-muted);
+    }
+    .footer-links {
+      display: flex;
+      gap: 16px;
+    }
+    .footer-link {
+      font-size: 12px;
+      color: var(--fg-subtle);
+      text-decoration: none;
+      transition: color 0.15s;
+    }
+    .footer-link:hover { color: var(--fg-muted); }
+
+    /* ── Animations ─────────────────────────────────────────────────────── */
+    @keyframes fadeSlideUp {
+      from { opacity: 0; transform: translateY(8px); }
+      to { opacity: 1; transform: translateY(0); }
+    }
+    .animate-in {
+      animation: fadeSlideUp 0.4s ease forwards;
+    }
+
+    /* Filled field glow */
+    input.filled, select.filled, textarea.filled {
+      border-color: rgba(52,211,153,0.2);
+    }
+
+    /* Responsive nav */
+    @media (max-width: 640px) {
+      .nav-links { display: none; }
+      .page-title { font-size: 22px; }
+    }
+  </style>
+</head>
+<body class="dot-grid">
+
+<!-- ── Nav ──────────────────────────────────────────────────────────────── -->
+<nav>
+  <div class="nav-inner">
+    <a href="/" class="nav-logo">
+      <div class="nav-logo-icon">OA</div>
+      OpenAffiliate
+    </a>
+    <div class="nav-links">
+      <a href="/programs" class="nav-link">Programs</a>
+      <a href="/categories" class="nav-link">Categories</a>
+      <a href="/rankings" class="nav-link">Rankings</a>
+      <a href="/docs" class="nav-link">Docs</a>
+      <a href="/submit" class="nav-link active">Submit</a>
+    </div>
+    <div class="nav-right">
+      <a href="/api" class="btn-sm">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+        API
+      </a>
+    </div>
+  </div>
+</nav>
+
+<!-- ── Main ──────────────────────────────────────────────────────────────── -->
+<main>
+
+  <!-- ─ Form state ──────────────────────────────────────────────────────── -->
+  <div id="form-state">
+
+    <!-- Page header -->
+    <div class="page-header animate-in">
+      <a href="https://github.com/Affitor/open-affiliate" target="_blank" class="dev-escape">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.3 3.44 9.8 8.2 11.38.6.11.82-.26.82-.58v-2.16c-3.34.72-4.04-1.61-4.04-1.61-.54-1.38-1.33-1.75-1.33-1.75-1.08-.74.08-.73.08-.73 1.2.09 1.83 1.23 1.83 1.23 1.07 1.83 2.8 1.3 3.49 1 .1-.78.42-1.3.76-1.6-2.67-.3-5.47-1.33-5.47-5.93 0-1.31.47-2.38 1.23-3.22-.12-.3-.53-1.52.12-3.18 0 0 1-.32 3.3 1.23a11.5 11.5 0 0 1 3-.4c1.02 0 2.04.14 3 .4 2.28-1.55 3.29-1.23 3.29-1.23.65 1.66.24 2.88.12 3.18.77.84 1.23 1.91 1.23 3.22 0 4.61-2.81 5.63-5.48 5.92.43.37.81 1.1.81 2.22v3.29c0 .32.22.7.83.58C20.57 21.8 24 17.3 24 12c0-6.63-5.37-12-12-12z"/></svg>
+        Developer? List via GitHub
+        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7"/><path d="M7 7h10v10"/></svg>
+      </a>
+
+      <h1 class="page-title">List your affiliate program</h1>
+      <p class="page-subtitle">Reach 750+ affiliates and AI agents that recommend products to SaaS buyers every day. Takes about 3 minutes.</p>
+
+      <div class="trust-strip">
+        <span class="trust-item">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+          Free forever
+        </span>
+        <span class="trust-sep">·</span>
+        <span class="trust-item">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          750+ programs listed
+        </span>
+        <span class="trust-sep">·</span>
+        <span class="trust-item">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          Discovered by AI agents
+        </span>
+        <span class="trust-sep">·</span>
+        <span class="trust-item">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
+          Verified-by-Stripe option
+        </span>
+      </div>
+    </div>
+
+    <!-- Split layout -->
+    <div class="split-layout">
+
+      <!-- ─ Form column ──────────────────────────────────────────────────── -->
+      <div class="form-col">
+
+        <!-- Step 1: Magic URL -->
+        <div class="magic-card animate-in">
+          <div class="magic-label">
+            <span class="step-num">1</span>
+            Start here
+          </div>
+          <div class="magic-heading">Paste your affiliate program URL</div>
+          <div class="magic-subhead">We'll read your page and fill in the details automatically.</div>
+          <div class="url-row">
+            <div class="input-prefix" style="flex:1">
+              <span class="prefix-text">https://</span>
+              <input type="text" id="program-url" placeholder="yourcompany.com/affiliates" oninput="onUrlInput()" />
+            </div>
+            <button class="fetch-btn" id="fetch-btn" onclick="simulateFetch()" disabled>
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+              Auto-fill
+            </button>
+          </div>
+          <div class="fetch-status" id="fetch-status">
+            <div class="spinner"></div>
+            Reading your page...
+          </div>
+          <div class="fetch-status success" id="fetch-success" style="display:none">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            Found your program — form filled in below. Review and adjust anything.
+          </div>
+        </div>
+
+        <!-- Step 2: Program basics -->
+        <div class="form-section animate-in" style="animation-delay:0.05s">
+          <div class="form-section-header">
+            <span class="section-step active">2</span>
+            <span class="form-section-title">About your program</span>
+          </div>
+          <div class="form-section-body">
+            <div class="field">
+              <label for="name">Program name <span class="hint">Your product name, e.g. "Acme Analytics"</span></label>
+              <input type="text" id="name" placeholder="Acme Analytics" oninput="updatePreview()" />
+            </div>
+            <div class="field-group cols-2">
+              <div class="field">
+                <label for="website">Website</label>
+                <div class="input-prefix">
+                  <span class="prefix-text">https://</span>
+                  <input type="text" id="website" placeholder="acme.com" oninput="updatePreview()" />
+                </div>
+              </div>
+              <div class="field">
+                <label for="signup-url">Affiliate signup page</label>
+                <div class="input-prefix">
+                  <span class="prefix-text">https://</span>
+                  <input type="text" id="signup-url" placeholder="acme.com/affiliates" />
+                </div>
+              </div>
+            </div>
+            <div class="field">
+              <label for="category">Category</label>
+              <div class="select-wrap">
+                <select id="category" onchange="updatePreview()">
+                  <option value="">Select a category…</option>
+                  <option>AI / Machine Learning</option>
+                  <option>Analytics</option>
+                  <option>Communication</option>
+                  <option>CRM / Sales</option>
+                  <option>Customer Success</option>
+                  <option>Design Tools</option>
+                  <option>Developer Tools</option>
+                  <option>E-commerce</option>
+                  <option>Education / Learning</option>
+                  <option>Finance / Fintech</option>
+                  <option>HR / Recruiting</option>
+                  <option>Infrastructure / DevOps</option>
+                  <option>Legal / Compliance</option>
+                  <option>Marketing / SEO</option>
+                  <option>Payments</option>
+                  <option>Productivity</option>
+                  <option>Project Management</option>
+                  <option>Security</option>
+                  <option>Support / Helpdesk</option>
+                  <option>Video / Webinars</option>
+                </select>
+              </div>
+            </div>
+            <div class="field">
+              <label for="pitch">One-line pitch <span class="hint">What does your product do? (shown to affiliates)</span></label>
+              <input type="text" id="pitch" placeholder="The analytics platform that makes data teams 10x faster." maxlength="120" oninput="updatePreview()" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 3: Commission -->
+        <div class="form-section animate-in" style="animation-delay:0.1s">
+          <div class="form-section-header">
+            <span class="section-step active">3</span>
+            <span class="form-section-title">What do affiliates earn?</span>
+          </div>
+          <div class="form-section-body">
+            <div class="field">
+              <label>Commission type</label>
+              <div class="type-pills">
+                <button class="type-pill selected" onclick="selectType(this, 'Recurring')" id="pill-recurring">Recurring %</button>
+                <button class="type-pill" onclick="selectType(this, 'One-time')" id="pill-onetime">One-time %</button>
+                <button class="type-pill" onclick="selectType(this, 'Flat fee')" id="pill-flat">Flat fee ($)</button>
+                <button class="type-pill" onclick="selectType(this, 'Tiered')" id="pill-tiered">Tiered</button>
+              </div>
+            </div>
+            <div class="field-group cols-2">
+              <div class="field">
+                <label for="commission-rate">Commission rate</label>
+                <div class="input-suffix">
+                  <input type="text" id="commission-rate" placeholder="25" oninput="updatePreview()" />
+                  <span class="suffix-text">%</span>
+                </div>
+              </div>
+              <div class="field">
+                <label for="cookie-window">
+                  How long is a referral tracked?
+                  <span class="hint">cookie window</span>
+                </label>
+                <div class="select-wrap">
+                  <select id="cookie-window" onchange="updatePreview()">
+                    <option value="14">14 days</option>
+                    <option value="30" selected>30 days</option>
+                    <option value="60">60 days</option>
+                    <option value="90">90 days</option>
+                    <option value="180">6 months</option>
+                    <option value="365">1 year</option>
+                    <option value="0">Lifetime</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- Advanced toggle -->
+          <button class="advanced-toggle" id="advanced-toggle" onclick="toggleAdvanced()">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"/></svg>
+            Add more details
+            <span style="color:var(--fg-subtle);font-size:11px;margin-left:2px">(payout method, approval, restrictions)</span>
+          </button>
+          <div class="advanced-body" id="advanced-body">
+            <div class="field-group cols-2">
+              <div class="field">
+                <label for="payout-min">Minimum payout</label>
+                <div class="input-prefix">
+                  <span class="prefix-text">$</span>
+                  <input type="number" id="payout-min" placeholder="50" min="0" />
+                </div>
+              </div>
+              <div class="field">
+                <label for="payout-freq">Paid out</label>
+                <div class="select-wrap">
+                  <select id="payout-freq">
+                    <option>Monthly</option>
+                    <option>Every 2 weeks</option>
+                    <option>Net-30</option>
+                    <option>Net-60</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="field-group cols-2">
+              <div class="field">
+                <label for="payout-method">Paid via</label>
+                <div class="select-wrap">
+                  <select id="payout-method">
+                    <option>PayPal</option>
+                    <option>Bank transfer</option>
+                    <option>Stripe</option>
+                    <option>Check</option>
+                  </select>
+                </div>
+              </div>
+              <div class="field">
+                <label for="approval">Application review</label>
+                <div class="select-wrap">
+                  <select id="approval">
+                    <option>Manual (1–3 days)</option>
+                    <option>Auto-approved</option>
+                    <option>Invite only</option>
+                  </select>
+                </div>
+              </div>
+            </div>
+            <div class="field">
+              <label for="restrictions">Any restrictions? <span class="hint">optional — e.g. "No coupon sites"</span></label>
+              <input type="text" id="restrictions" placeholder="e.g. No coupon sites, no paid search on brand terms" />
+            </div>
+          </div>
+        </div>
+
+        <!-- Step 4: Identity -->
+        <div class="identity-section animate-in" style="animation-delay:0.15s">
+          <div class="identity-head">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+            Your email (so you can edit your listing later)
+          </div>
+          <div class="field">
+            <label for="email">Work email</label>
+            <input type="email" id="email" placeholder="you@yourcompany.com" />
+          </div>
+          <label class="checkbox-row">
+            <input type="checkbox" id="works-here" />
+            <span class="checkbox-label">
+              <strong>I work at this company</strong> — lets us add a
+              <span class="verified-badge-inline">
+                <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                Verified
+              </span>
+              badge later
+            </span>
+          </label>
+        </div>
+
+        <!-- Submit -->
+        <div class="submit-row animate-in" style="animation-delay:0.2s">
+          <button class="btn-primary" onclick="showSuccess()">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+            Submit for review
+          </button>
+          <p class="submit-note">
+            Free forever. No account needed. We'll email you a link to edit your listing.
+            <br />By submitting you agree to our <a href="/terms">terms</a>. Review usually takes a few minutes.
+          </p>
+        </div>
+
+      </div><!-- /form-col -->
+
+      <!-- ─ Preview column ─────────────────────────────────────────────── -->
+      <div class="preview-col">
+        <div class="preview-wrapper">
+
+          <div class="preview-label">
+            <span class="live-dot">Live preview</span>
+          </div>
+
+          <!-- Program card -->
+          <div class="program-card" id="preview-card">
+            <div class="card-top">
+              <div class="card-logo" id="prev-logo">?</div>
+              <div class="card-meta">
+                <div class="card-name empty" id="prev-name">Your program name</div>
+                <div class="card-category" id="prev-category">Category · openaffiliate.dev</div>
+              </div>
+            </div>
+            <div class="card-badges" id="prev-badges">
+              <span class="badge badge-commission" id="prev-commission">— commission</span>
+              <span class="badge badge-cookie" id="prev-cookie">30 day cookie</span>
+              <span class="badge badge-type" id="prev-type">Recurring</span>
+            </div>
+            <div class="card-description empty" id="prev-description">
+              Your one-line pitch will appear here — what makes affiliates want to promote you?
+            </div>
+            <div class="card-footer">
+              <span class="card-cta">
+                Apply to program
+                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>
+              </span>
+              <span class="card-score">
+                <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>
+                Score pending
+              </span>
+            </div>
+          </div>
+
+          <!-- Context box -->
+          <div class="preview-ctx">
+            <strong>This is exactly what affiliates and AI agents will see</strong> in the directory.
+            <ul>
+              <li>Affiliates browse by commission rate and category</li>
+              <li>AI agents use your listing to recommend your product to buyers</li>
+              <li>Verified programs get a blue checkmark and rank higher</li>
+            </ul>
+          </div>
+
+          <!-- API context (subtle) -->
+          <div style="background:rgba(0,0,0,0.3);border:1px solid rgba(255,255,255,0.05);border-radius:10px;padding:12px 14px;font-family:var(--mono);font-size:11px;color:var(--fg-subtle);">
+            <div style="color:var(--fg-subtle);margin-bottom:6px;font-family:var(--font);font-size:10px;text-transform:uppercase;letter-spacing:0.06em">Also discoverable via API</div>
+            <span style="color:#4ade80">GET</span> <span style="color:rgba(255,255,255,0.4)">/api/programs/</span><span id="prev-slug-api" style="color:rgba(255,255,255,0.6)">your-program</span>
+          </div>
+
+        </div>
+      </div><!-- /preview-col -->
+
+    </div><!-- /split-layout -->
+  </div><!-- /form-state -->
+
+  <!-- ─ Success state ──────────────────────────────────────────────────── -->
+  <div id="success-state">
+    <div class="page-header" style="text-align:center;padding-top:60px">
+      <!-- intentionally empty, content below -->
+    </div>
+    <div class="success-wrap animate-in">
+
+      <div class="success-icon">
+        <svg width="36" height="36" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+      </div>
+
+      <h1 class="success-title">Submitted — you're in the queue</h1>
+      <p class="success-subtitle">
+        We review every submission manually. Most programs go live within a few minutes during business hours.
+      </p>
+
+      <div class="success-email-badge">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+        Check your email for an edit link
+      </div>
+
+      <div class="what-next">
+        <div class="what-next-title">What happens next</div>
+        <div class="next-steps">
+          <div class="next-step done">
+            <div class="next-step-num">
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+            </div>
+            <div class="next-step-body">
+              <div class="next-step-title">Submitted</div>
+              <div class="next-step-desc">Your program details are in our review queue. Done!</div>
+            </div>
+          </div>
+          <div class="next-step">
+            <div class="next-step-num">2</div>
+            <div class="next-step-body">
+              <div class="next-step-title">Quick review</div>
+              <div class="next-step-desc">We check that commission details are accurate and the signup URL works. Usually done in minutes.</div>
+            </div>
+          </div>
+          <div class="next-step">
+            <div class="next-step-num">3</div>
+            <div class="next-step-body">
+              <div class="next-step-title">Live in the directory</div>
+              <div class="next-step-desc">Your program appears in search results, category pages, and the API. Affiliates and AI agents can discover it immediately.</div>
+            </div>
+          </div>
+          <div class="next-step">
+            <div class="next-step-num">4</div>
+            <div class="next-step-body">
+              <div class="next-step-title">Claim &amp; verify for the
+                <span class="verified-badge-inline">
+                  <svg width="9" height="9" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                  Verified
+                </span>
+                badge
+              </div>
+              <div class="next-step-desc">We'll email you a link. Connect your Stripe account to confirm real payouts — verified programs rank higher and convert more affiliates.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="success-actions">
+        <a href="/programs" class="btn-outline">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+          Browse programs
+        </a>
+        <a href="/submit" class="btn-outline" onclick="resetForm(event)">
+          <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Submit another program
+        </a>
+      </div>
+
+    </div>
+  </div><!-- /success-state -->
+
+</main>
+
+<!-- ── Footer ──────────────────────────────────────────────────────────── -->
+<footer>
+  <div class="footer-inner">
+    <div class="footer-logo">
+      <div class="nav-logo-icon" style="width:18px;height:18px;font-size:10px">OA</div>
+      OpenAffiliate — open source, community-driven
+    </div>
+    <div class="footer-links">
+      <a href="/programs" class="footer-link">Programs</a>
+      <a href="/docs" class="footer-link">Docs</a>
+      <a href="https://github.com/Affitor/open-affiliate" class="footer-link">GitHub</a>
+      <a href="/feedback" class="footer-link">Feedback</a>
+    </div>
+  </div>
+</footer>
+
+<script>
+  /* ── State ───────────────────────────────────────────────────────────── */
+  var commissionType = 'Recurring';
+  var fetchTimeout = null;
+
+  /* ── URL input → enable Auto-fill ───────────────────────────────────── */
+  function onUrlInput() {
+    var url = document.getElementById('program-url').value.trim();
+    document.getElementById('fetch-btn').disabled = url.length < 5;
+    // Mirror to website field
+    document.getElementById('website').value = url.replace(/\/affiliates?.*$/, '');
+    updatePreview();
+  }
+
+  /* ── Simulate fetch & autofill ──────────────────────────────────────── */
+  function simulateFetch() {
+    var status = document.getElementById('fetch-status');
+    var success = document.getElementById('fetch-success');
+    var btn = document.getElementById('fetch-btn');
+
+    status.style.display = 'flex';
+    success.style.display = 'none';
+    btn.disabled = true;
+    btn.innerHTML = '<div class="spinner" style="border-top-color:#0a1a12"></div> Reading…';
+
+    clearTimeout(fetchTimeout);
+    fetchTimeout = setTimeout(function() {
+      status.style.display = 'none';
+
+      // Pre-fill with demo data
+      document.getElementById('name').value = 'Acme Analytics';
+      document.getElementById('website').value = 'acme.com';
+      document.getElementById('signup-url').value = 'acme.com/affiliates';
+      document.getElementById('pitch').value = 'The analytics platform that makes data teams 10× faster.';
+      document.getElementById('commission-rate').value = '30';
+      document.getElementById('cookie-window').value = '60';
+
+      var catSel = document.getElementById('category');
+      for (var i = 0; i < catSel.options.length; i++) {
+        if (catSel.options[i].text === 'Analytics') {
+          catSel.selectedIndex = i;
+          break;
+        }
+      }
+
+      success.style.display = 'flex';
+      btn.disabled = false;
+      btn.innerHTML = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg> Done';
+
+      updatePreview();
+    }, 1600);
+  }
+
+  /* ── Commission type pills ──────────────────────────────────────────── */
+  function selectType(btn, type) {
+    commissionType = type;
+    document.querySelectorAll('.type-pill').forEach(function(p) { p.classList.remove('selected'); });
+    btn.classList.add('selected');
+
+    // Update suffix label
+    var suffix = document.querySelector('.input-suffix .suffix-text');
+    if (suffix) {
+      suffix.textContent = type === 'Flat fee ($)' ? '$' : '%';
+    }
+
+    updatePreview();
+  }
+
+  /* ── Advanced toggle ────────────────────────────────────────────────── */
+  function toggleAdvanced() {
+    var toggle = document.getElementById('advanced-toggle');
+    var body = document.getElementById('advanced-body');
+    toggle.classList.toggle('open');
+    body.classList.toggle('open');
+  }
+
+  /* ── Live preview update ────────────────────────────────────────────── */
+  function updatePreview() {
+    var name = document.getElementById('name').value.trim();
+    var category = document.getElementById('category').value;
+    var pitch = document.getElementById('pitch').value.trim();
+    var rate = document.getElementById('commission-rate').value.trim();
+    var cookie = document.getElementById('cookie-window').value;
+
+    // Name
+    var nameEl = document.getElementById('prev-name');
+    if (name) {
+      nameEl.textContent = name;
+      nameEl.classList.remove('empty');
+    } else {
+      nameEl.textContent = 'Your program name';
+      nameEl.classList.add('empty');
+    }
+
+    // Logo initials
+    var logoEl = document.getElementById('prev-logo');
+    if (name) {
+      var words = name.split(' ');
+      var initials = words.length >= 2
+        ? (words[0][0] + words[1][0]).toUpperCase()
+        : name.slice(0, 2).toUpperCase();
+      logoEl.textContent = initials;
+      logoEl.classList.add('filled');
+    } else {
+      logoEl.textContent = '?';
+      logoEl.classList.remove('filled');
+    }
+
+    // Category
+    var catEl = document.getElementById('prev-category');
+    catEl.textContent = (category || 'Category') + ' · openaffiliate.dev';
+
+    // Description
+    var descEl = document.getElementById('prev-description');
+    if (pitch) {
+      descEl.textContent = pitch;
+      descEl.classList.remove('empty');
+    } else {
+      descEl.textContent = 'Your one-line pitch will appear here — what makes affiliates want to promote you?';
+      descEl.classList.add('empty');
+    }
+
+    // Commission badge
+    var commBadge = document.getElementById('prev-commission');
+    var suffix = commissionType === 'Flat fee ($)' ? '' : '%';
+    var prefix = commissionType === 'Flat fee ($)' ? '$' : '';
+    commBadge.textContent = rate ? prefix + rate + suffix + ' commission' : '— commission';
+
+    // Cookie badge
+    var cookieEl = document.getElementById('prev-cookie');
+    var cookieMap = {'0':'Lifetime cookie','14':'14d cookie','30':'30d cookie','60':'60d cookie','90':'90d cookie','180':'6mo cookie','365':'1yr cookie'};
+    cookieEl.textContent = cookieMap[cookie] || cookie + 'd cookie';
+
+    // Type badge
+    document.getElementById('prev-type').textContent = commissionType;
+
+    // Card glow
+    var card = document.getElementById('preview-card');
+    if (name || pitch || rate) {
+      card.classList.add('has-content');
+    } else {
+      card.classList.remove('has-content');
+    }
+
+    // API slug
+    var slug = name
+      ? name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')
+      : 'your-program';
+    document.getElementById('prev-slug-api').textContent = slug;
+  }
+
+  /* ── Show success ───────────────────────────────────────────────────── */
+  function showSuccess() {
+    document.getElementById('form-state').classList.add('hidden');
+    var s = document.getElementById('success-state');
+    s.style.display = 'block';
+    s.classList.add('visible');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+
+  function resetForm(e) {
+    e.preventDefault();
+    document.getElementById('form-state').classList.remove('hidden');
+    document.getElementById('success-state').style.display = 'none';
+    document.getElementById('success-state').classList.remove('visible');
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }
+</script>
+
+</body>
+</html>

--- a/docs/onboarding-dual-audience-plan.md
+++ b/docs/onboarding-dual-audience-plan.md
@@ -1,0 +1,146 @@
+# OpenAffiliate — Dual-Audience Onboarding Plan
+
+> 2026-06-14. Goal: make OpenAffiliate work for **technical** (founders/devs, AI agents) **and non-technical** (growth/marketing/BizDev, affiliate partners) users, on **both** sides of the marketplace (list a program / find + promote), plus affiliate **networks** (bulk). Today there is exactly one path — a GitHub PR — and it's wrong for 3 of the 4 personas.
+
+---
+
+## 1. The core reframe
+
+Stop thinking "one apply page." There are **two axes** and **five cells**:
+
+```
+                 SUPPLY (list a program)            DEMAND (find + get a link)
+   TECHNICAL     A · Founder / Developer            D-agent · Dev / AI agent
+                 → GitHub PR + CLI + MCP            → MCP/CLI read (exists) + write tools
+   NON-TECHNICAL B · Growth / Marketing / BizDev    D-creator · Affiliate partner / creator
+                 → no-code form (GAP #1)            → "Get my link" (GAP #2)
+   BULK          C · Affiliate network — CSV/API import + review gate (spans supply)
+```
+
+**The two missing flows (both P0):** a *no-code/no-GitHub* way to **list** (B), and a *real "get a link"* instead of an outbound bounce (D-creator). They converge on the **same two primitives**: (1) a server intake that doesn't end on GitHub, and (2) an account-light **email magic-link** identity. Build those two → B, C, and D all unlock.
+
+---
+
+## 2. Current state (verified in code, the gap)
+
+- **One real write path = a GitHub PR adding `programs/{slug}.yaml`.** Even `/submit` (marketed "easiest, no GitHub") just generates YAML in the browser and `window.open()`s GitHub's new-file editor — the user still needs a GitHub account and must understand fork/branch/commit/PR. A marketer hits a hard wall here; conversion ≈ 0.
+- **No backend for programs.** 755 static YAML → `programs.json` at build. Supabase exists but only for **analytics/votes** (no `programs`/`users`/`applications` tables). No auth, no dashboard, no claim.
+- **Demand side does not exist.** A program page's only action is an outbound `Apply to program` → the brand's *external* signup. OpenAffiliate mints no link, captures no partner, knows no one applied.
+- **CI is solid but has a hole:** `pr-programs.yml` validates + URL-verifies + auto-merges, but it calls `scripts/enrich-program.ts` **which doesn't exist** (`|| true` no-op). Dedup/logo/enrich silently don't run.
+
+---
+
+## 3. The five flows (concrete)
+
+### Flow A — Founder / Developer lists a program  ·  *technical supply*  ·  [keep + enhance, P2]
+GitHub PR already works for this persona. Enhancements:
+1. `npx openaffiliate submit` — CLI auto-drafts the YAML **from the product URL** (AI fills commission/category/agent-prompt), then posts it through the new server intake (opens the PR for them).
+2. MCP/SDK `submit_program` tool — "Add my program to OpenAffiliate" works from Cursor/Claude.
+3. After it's live: **claim + owner dashboard** (live status, search rank, clicks, applies) so submission isn't a black hole.
+4. The reward/upsell: "Listed free here. Run the program for real on **Affitor** (Stripe-native tracking + payouts)."
+
+### Flow B — Growth / Marketing / BizDev lists a program  ·  *non-technical supply*  ·  **[GAP #1, P0]**
+A true no-code wizard at `/list` (replaces the GitHub dead-end of `/submit`):
+1. **Paste your product URL** → AI auto-drafts the listing from your public affiliates page (name, category, commission, cookie, payout).
+2. **Review/edit** in a friendly form — **YAML is never shown.**
+3. Enter **email** (magic-link — no GitHub, no password).
+4. **"Submit for review"** → lands in a `submissions` table → a status page ("under review").
+5. **Auto-approve when clean** (URL reachable + no duplicate + low spam score) → a **GitHub App bot opens the PR for them** → existing CI auto-merges → live in minutes. Otherwise a one-click admin review.
+6. Email: "You're live → **claim & verify** to earn the Verified badge."
+**They never see GitHub.** This single change makes the "no GitHub needed" promise finally true.
+
+### Flow C — Affiliate network bulk-lists  ·  *bulk supply*  ·  [P1]
+1. Network gets an **API key / partner account** (gated, not anonymous — bulk is trusted/partnered).
+2. Upload **CSV/JSON** (or connect a feed) mapped to the schema.
+3. `scripts/import-bulk.ts` normalizes → validates (zod + schema) → **dedupes by domain** against the 755 → emits N YAML files → **one batched PR** tagged `source: <network>`, `verified: false`.
+4. **Maintainer reviews the batch** (aggregate report: "312 ok / 11 dup / 4 url-fail"). **No auto-merge above N files.**
+5. Network attribution + a network landing page (this is distribution they can sell upstream).
+
+### Flow D — Affiliate partner gets a link  ·  *non-technical demand*  ·  **[GAP #2, P0]**
+Replace the dumb outbound `Apply` with a smart CTA on `/programs/{slug}`, branched on **one new YAML field** `powered_by`:
+- **`powered_by: affitor`** → **"Get your affiliate link"** → deep-link into Affitor's magic-link partner apply → **instant tracked link + dashboard + payouts**. Trust anchor: "Verified by Stripe."
+- **External program** → **"Apply to program"** → `signup_url` (+ `?utm_source=openaffiliate`), keep the existing `outbound_click` event. Plus optional **"Save to my list" / applied-tracker** (magic-link account) so a creator managing many programs isn't lost.
+- Surfaced trust signals: Verified badge, real commission/cookie data, votes/Sift rank, "instant approval."
+
+### Flow E — AI agent  ·  *technical, both sides*  ·  [P2]
+Read tools exist (`search_programs`, `get_program`). Add the long-promised **write tools** — `submit_program`, `claim_program`, `get_link`/`apply` — to MCP + CLI + SDK, all proxying the same server intake. One canonical pipeline for dev, non-tech human, and agent alike.
+
+---
+
+## 4. Architecture — non-technical intake without breaking the open ethos
+
+**Invariant:** YAML-in-Git stays the **single source of truth** (it powers `programs.json`, the API, MCP, SEO, the open story). A database is added **only as a staging buffer for un-published state** — pending submissions, claim tokens, bulk batches. Nothing *published* lives only in the DB; if the DB vanished, the public registry/API/agents keep working.
+
+```
+   Developer ─ direct PR ───────────────────────────────────┐
+   Non-tech  ─ POST /api/submit ─┐                           │
+   AI agent  ─ submit_program ───┤                           │
+   Network   ─ import-bulk CLI ──┤                           │
+                                 ▼                           │
+                    Supabase STAGING (already wired)         │
+                    submissions │ claims  (pending only)     │
+                    validate · enrich(shared) · dedup ·      │
+                    spam-score · DNS/email claim-verify       │
+                                 │ auto-approve OR /admin     │
+                                 ▼                           │
+                    GitHub App bot opens/updates PR ─────────┤
+                                                             ▼
+                    GIT = SOURCE OF TRUTH (programs/*.yaml)
+                                 │ existing pr-programs.yml (dedup·verify·auto-merge)
+                                 ▼
+                    build-registry.ts → programs.json  (unchanged)
+                                 ▼
+              Web · REST API · MCP · CLI/SDK · AGENTS.md
+                                 │  /programs/{slug} CTA
+                    powered_by:affitor? ── yes → affitor.com/p/{slug} (tracked link)
+                                        └─ no  → signup_url (+utm)
+```
+
+**Keystone (do first):** write the missing **`scripts/lib/enrich.ts`** and import it from *both* CI and `/api/submit` so the web path and the PR path enrich/validate identically. Nothing is consistent without it.
+
+Reuse the proven `/api/votes` + `/api/events` service-role + IP-hash + honeypot pattern for `/api/submit` and `/api/claim`. New migration `007_submissions_claims.sql` mirrors the existing policy style.
+
+---
+
+## 5. OpenAffiliate ↔ Affitor boundary
+
+OpenAffiliate is **discovery (top of funnel)**; Affitor is the **engine (tracking, commissions, payouts)**. The boundary is **one optional, additive field** (`powered_by: affitor` + `affitor_program_slug`):
+- External programs: unchanged behaviour (route to their own `signup_url`). OpenAffiliate stays honest open discovery.
+- Affitor-run programs: richer in-network "Get your link" → instant tracked link.
+- **Flywheel:** discover (open) → **claim** a listing (own it) → **"Run it on Affitor"** (flip `powered_by`) → tracked program. Listing is **free forever**; money sits only on the Affitor engine, never on being found. The open registry never becomes a walled garden — it's a single field.
+
+---
+
+## 6. Trust & quality model (resolves volume-vs-curation)
+
+Three tiers, so frictionless self-serve doesn't dilute the signal partners rely on:
+1. **Community** — self-served or auto-discovered, `verified: false`. Frictionless single submit.
+2. **Claimed** — owner verified via **DNS TXT** (authoritative) or **email-on-domain** (fallback) → editable, `verified: true`.
+3. **Stripe-verified** — Affitor-run, real money flows ("Verified by Stripe") — the strongest payout-credibility signal.
+
+Rules: single submit = frictionless; **bulk gated by review** (no wholesale auto-merge); ownership precedence **owner-claimed > network-source > community** (so a network batch can't clobber a brand's curated page).
+
+---
+
+## 7. Roadmap
+
+| Phase | Build | Unlocks | Effort |
+|---|---|---|---|
+| **P0** | `enrich.ts` (keystone) · `/api/submit` + `submissions` table + `/admin` review + GitHub App bot-PR · rewire `/submit` → no-code `/list` · demand CTA branch (`powered_by` → Affitor handoff; `utm` for external) | **B (non-tech list) + D-creator (get a link)** — the two non-technical halves the goal demands | M |
+| **P1** | Claim/verify (DNS TXT + email fallback) + email **magic-link identity** · agent **write tools** (submit/claim) · owner dashboard | Ownership + Verified pipeline + agent-native supply; preps C | M |
+| **P2** | Bulk network import (`import-bulk.ts` + batch-PR + review gate) · full Affitor flywheel (claim → run on Affitor) · native partner accounts/link-tracking (in Affitor) | **C (networks)** + monetization seam | M–L |
+
+---
+
+## 8. The one sharp insight
+
+OpenAffiliate's **discovery** layer is mature for all four personas; its **transaction** layer (submit-for-non-coders, get-a-link-for-partners) is missing. Both gaps converge on **two primitives — a no-code server intake (form → bot PR) and email magic-link identity.** Ship those two and B, C, D unlock together, with Affitor as the monetized engine that the technical and trust-sensitive personas graduate into.
+
+### First PR to cut (P0, smallest viable)
+1. `scripts/lib/enrich.ts` (+ wire into `pr-programs.yml` and a new `/api/submit`).
+2. `supabase/migrations/007_submissions_claims.sql`.
+3. `POST /api/submit` + `GET /api/submit/status/[id]` + `/admin` approve (service-role + honeypot, copy `/api/events`).
+4. GitHub App bot (the only DB→Git writer).
+5. Rewire `/submit` page → server intake (kill the GitHub redirect) + fix the false "no GitHub / agent opens PR" copy in `/docs/submit` and `AGENTS.md`.
+
+*Key files: `src/app/submit/page.tsx` (replace GitHub redirect) · `src/app/api/events/route.ts` + `api/votes/route.ts` (pattern to copy) · `.github/workflows/pr-programs.yml` (backbone, calls the missing script) · `scripts/build-registry.ts` (YAML→json, preserve) · `schema/program.schema.json` (additive `powered_by`) · `src/app/programs/[slug]/page.tsx` (Apply CTA / Affitor boundary).*

--- a/docs/onboarding-flows.html
+++ b/docs/onboarding-flows.html
@@ -1,0 +1,259 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>OpenAffiliate — Dual-Audience Onboarding Plan</title>
+<script>
+  (function () {
+    const s = localStorage.getItem('theme');
+    document.documentElement.classList.toggle('dark', s ? s === 'dark' : matchMedia('(prefers-color-scheme: dark)').matches);
+  })();
+</script>
+<style>
+  :root{
+    --bg:#FAF9F5; --surface:#fff; --surface2:#F0EEE6; --ink:#141413; --body:#3D3D3A; --muted:#87867F;
+    --line:#D9D7CD; --line2:#ECEAE2;
+    --clay:#C45A3B; --clay-bg:#FBEEE9; --clay-line:#E9C7BC;
+    --olive:#5E7A41; --olive-bg:#EEF3E7; --olive-line:#CFE0BC;
+    --gold:#A9802F; --gold-bg:#FAF2E0; --gold-line:#ECD9Ae;
+    --blue:#3F6F8C; --blue-bg:#E9F1F6; --blue-line:#C3DCE8;
+    --serif:ui-serif,Georgia,"Times New Roman",serif;
+    --sans:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    --mono:ui-monospace,"SF Mono",Menlo,Consolas,monospace;
+  }
+  html.dark{
+    --bg:#141413; --surface:#1E1E1C; --surface2:#27272400; --ink:#FAF9F5; --body:#CFCDC4; --muted:#8C8B82;
+    --line:#34332F; --line2:#2A2A27;
+    --clay:#E08A6C; --clay-bg:#2A1d18; --clay-line:#4a3127;
+    --olive:#9DB87A; --olive-bg:#1d2417; --olive-line:#33401f;
+    --gold:#D6B36A; --gold-bg:#27210f; --gold-line:#43391c;
+    --blue:#80A9C4; --blue-bg:#16242c; --blue-line:#264049;
+  }
+  *{box-sizing:border-box;margin:0;padding:0}
+  body{background:var(--bg);color:var(--body);font-family:var(--sans);font-size:14px;line-height:1.55;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1180px;margin:0 auto;padding:0 26px 80px}
+  code,.mono{font-family:var(--mono);font-size:.85em}
+  /* header */
+  header{border-bottom:1px solid var(--line);background:var(--surface);position:sticky;top:0;z-index:5}
+  .hin{max-width:1180px;margin:0 auto;padding:16px 26px;display:flex;align-items:center;gap:16px;flex-wrap:wrap}
+  h1{font-family:var(--serif);font-weight:500;font-size:21px;color:var(--ink);letter-spacing:-.01em}
+  .hin .sub{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.07em;color:var(--muted)}
+  .sp{flex:1}
+  #tt{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;padding:6px 11px;border:1px solid var(--line);border-radius:7px;background:transparent;color:var(--muted);cursor:pointer}
+  #tt:hover{color:var(--ink);border-color:var(--muted)}
+  section{padding:34px 0 4px}
+  h2{font-family:var(--serif);font-weight:500;font-size:18px;color:var(--ink);margin-bottom:3px;letter-spacing:-.01em}
+  .lead{color:var(--muted);font-size:13px;margin-bottom:18px;max-width:780px}
+  .kch{display:inline-block;font-family:var(--mono);font-size:9.5px;font-weight:700;text-transform:uppercase;letter-spacing:.05em;padding:2px 7px;border-radius:5px;vertical-align:middle}
+  .p0{background:var(--clay-bg);color:var(--clay);border:1px solid var(--clay-line)}
+  .p1{background:var(--gold-bg);color:var(--gold);border:1px solid var(--gold-line)}
+  .p2{background:var(--blue-bg);color:var(--blue);border:1px solid var(--blue-line)}
+  .ok{background:var(--olive-bg);color:var(--olive);border:1px solid var(--olive-line)}
+
+  /* matrix */
+  .matrix{display:grid;grid-template-columns:120px 1fr 1fr;gap:10px;align-items:stretch}
+  .mh{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.06em;color:var(--muted);display:flex;align-items:center;justify-content:center;text-align:center;padding:6px}
+  .rl{font-family:var(--mono);font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);display:flex;align-items:center;writing-mode:horizontal-tb;padding:8px;background:var(--surface2);border:1px solid var(--line2);border-radius:10px;justify-content:center;text-align:center}
+  .cell{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:14px 15px}
+  .cell h3{font-size:14px;color:var(--ink);font-weight:650;margin-bottom:2px;display:flex;align-items:center;gap:8px;flex-wrap:wrap}
+  .cell .who{font-size:12px;color:var(--muted);margin-bottom:9px}
+  .cell ul{list-style:none;display:flex;flex-direction:column;gap:5px}
+  .cell li{font-size:12.5px;padding-left:14px;position:relative}
+  .cell li::before{content:"→";position:absolute;left:0;color:var(--muted)}
+  .cell.gap{border-color:var(--clay-line);background:var(--clay-bg)}
+  .cell.has{border-color:var(--olive-line)}
+  .bulk{grid-column:2 / 4;background:var(--surface);border:1px dashed var(--line);border-radius:12px;padding:13px 15px}
+  .bulk h3{font-size:14px;color:var(--ink);font-weight:650;display:flex;gap:8px;align-items:center}
+  .bulk p{font-size:12.5px;color:var(--body);margin-top:4px}
+
+  /* flow cards */
+  .flows{display:grid;grid-template-columns:repeat(2,1fr);gap:12px}
+  .flow{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:15px 16px}
+  .flow.full{grid-column:1 / 3}
+  .flow .ft{display:flex;align-items:center;gap:9px;margin-bottom:3px;flex-wrap:wrap}
+  .flow .ft b{font-size:14px;color:var(--ink);font-weight:650}
+  .flow .ft .tag{font-family:var(--mono);font-size:10px;color:var(--muted)}
+  .flow ol{margin:8px 0 0 18px;display:flex;flex-direction:column;gap:4px}
+  .flow li{font-size:12.5px}
+  .flow .note{margin-top:9px;font-size:11.5px;color:var(--muted);border-top:1px solid var(--line2);padding-top:7px}
+  .flow code{background:var(--surface2);padding:1px 5px;border-radius:4px;color:var(--clay)}
+
+  /* arch */
+  .arch{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:18px 18px 8px;overflow-x:auto}
+  .arch pre{font-family:var(--mono);font-size:11.5px;line-height:1.5;color:var(--body);white-space:pre;min-width:640px}
+  .arch .key{color:var(--clay);font-weight:700}
+  .keystone{margin-top:12px;font-size:12.5px;background:var(--clay-bg);border:1px solid var(--clay-line);border-radius:9px;padding:10px 13px}
+  .keystone b{color:var(--clay)}
+
+  /* tiers + roadmap */
+  .cols{display:grid;grid-template-columns:1fr 1fr;gap:14px}
+  .panel{background:var(--surface);border:1px solid var(--line);border-radius:12px;padding:15px 16px}
+  .panel h3{font-size:13.5px;color:var(--ink);font-weight:650;margin-bottom:9px}
+  .tier{display:flex;gap:10px;align-items:flex-start;padding:7px 0;border-bottom:1px solid var(--line2);font-size:12.5px}
+  .tier:last-child{border:none}
+  .tier .b{width:9px;height:9px;border-radius:50%;margin-top:5px;flex:none}
+  table{width:100%;border-collapse:collapse;font-size:12.5px}
+  td{padding:8px 6px;border-bottom:1px solid var(--line2);vertical-align:top}
+  tr:last-child td{border:none}
+  .ph{font-family:var(--mono);font-weight:700;white-space:nowrap}
+  .insight{background:var(--ink);color:var(--bg);border-radius:14px;padding:22px 24px;margin-top:8px}
+  .insight b{color:var(--gold)}
+  .insight p{font-size:14px;line-height:1.6}
+  footer{margin-top:40px;border-top:1px solid var(--line);padding-top:18px;color:var(--muted);font-size:11.5px}
+  @media(max-width:820px){.flows,.cols{grid-template-columns:1fr}.flow.full,.bulk{grid-column:auto}.matrix{grid-template-columns:1fr}.rl{display:none}}
+</style>
+</head>
+<body>
+<header><div class="hin">
+  <div><h1>OpenAffiliate — Dual-Audience Onboarding</h1>
+  <div class="sub">2 axes · 5 cells · today there is only 1 path (GitHub PR)</div></div>
+  <div class="sp"></div>
+  <button id="tt">Theme</button>
+</div></header>
+
+<div class="wrap">
+
+<!-- MATRIX -->
+<section>
+  <h2>The reframe — who we're serving</h2>
+  <p class="lead">Stop thinking "one apply page." Two axes: <b>list a program (supply)</b> vs <b>find &amp; get a link (demand)</b>, crossed with <b>technical</b> vs <b>non-technical</b> — plus <b>networks</b> (bulk). The two red cells are missing today and are the whole point of this plan.</p>
+  <div class="matrix">
+    <div></div>
+    <div class="mh">Supply · list a program</div>
+    <div class="mh">Demand · find &amp; get a link</div>
+
+    <div class="rl">Technical<br>(GitHub / CLI / MCP)</div>
+    <div class="cell has">
+      <h3>A · Founder / Developer <span class="kch ok">works · enhance</span></h3>
+      <div class="who">YC / indie / VC-backed. Lives in GitHub &amp; CLI.</div>
+      <ul><li>GitHub PR already fine — keep as fast lane</li><li>Add <code>npx openaffiliate submit</code> (auto-draft YAML from URL)</li><li>MCP <code>submit_program</code> tool</li><li>Claim + owner dashboard (status, rank, clicks)</li></ul>
+    </div>
+    <div class="cell has">
+      <h3>D-agent · Dev / AI agent <span class="kch p2">P2</span></h3>
+      <div class="who">Builders &amp; agents consuming the registry.</div>
+      <ul><li>Read tools exist (search / get)</li><li>Add write tools: <code>get_link</code> / <code>apply</code></li><li>SDK link-gen for agent workflows</li></ul>
+    </div>
+
+    <div class="rl">Non-technical<br>(web form / no-code)</div>
+    <div class="cell gap">
+      <h3>B · Growth / Marketing / BizDev <span class="kch p0">GAP #1 · P0</span></h3>
+      <div class="who">Owns the program as a <i>channel</i>, not a codebase. Won't fork a repo.</div>
+      <ul><li>True no-code wizard at <code>/list</code></li><li>Form posts to a server — <b>never sees GitHub</b></li><li>Email magic-link ownership</li><li>"Claim your existing listing"</li></ul>
+    </div>
+    <div class="cell gap">
+      <h3>D-creator · Affiliate partner <span class="kch p0">GAP #2 · P0</span></h3>
+      <div class="who">Creator / blogger / newsletter. Wants a working link today.</div>
+      <ul><li>"Get my link" replaces the outbound bounce</li><li>Affitor handoff → instant tracked link</li><li>Saved / applied tracker</li><li>Stripe-verified payout trust</li></ul>
+    </div>
+
+    <div class="bulk">
+      <h3>C · Affiliate network <span class="kch p1">bulk · P1</span></h3>
+      <p>Spans the supply column, orthogonal to tech level. Authenticated <b>CSV/JSON/API bulk import</b> → normalize → dedupe-by-domain → <b>one batched PR</b> (no per-program form) → maintainer review gate (no wholesale auto-merge) + network attribution.</p>
+    </div>
+  </div>
+</section>
+
+<!-- CURRENT GAP -->
+<section>
+  <h2>Why it's broken today</h2>
+  <p class="lead">Verified in code: the registry is read-rich but <b>write-poor and demand-poor</b>.</p>
+  <div class="flows">
+    <div class="flow"><div class="ft"><b>One real write path = a GitHub PR</b></div>
+      <div class="note">Even <code>/submit</code> ("no GitHub needed") just builds YAML in the browser and opens GitHub's new-file editor — still needs a GitHub account + fork/branch/commit/PR literacy. A marketer hits a wall; conversion ≈ 0.</div></div>
+    <div class="flow"><div class="ft"><b>No backend for programs</b></div>
+      <div class="note">755 static YAML → <code>programs.json</code> at build. Supabase exists but only for votes/analytics — no <code>programs</code>/<code>users</code>/<code>applications</code>, no auth, no claim.</div></div>
+    <div class="flow"><div class="ft"><b>Demand side doesn't exist</b></div>
+      <div class="note">A program page's only action is an outbound <code>Apply</code> → the brand's external signup. OpenAffiliate mints no link, captures no partner, sees no conversion.</div></div>
+    <div class="flow"><div class="ft"><b>CI has a hole</b></div>
+      <div class="note"><code>pr-programs.yml</code> validates + verifies + auto-merges, but calls <code>scripts/enrich-program.ts</code> which <b>doesn't exist</b> (<code>|| true</code> no-op). Dedup/logo/enrich silently skipped.</div></div>
+  </div>
+</section>
+
+<!-- FLOWS -->
+<section>
+  <h2>The five flows (concrete)</h2>
+  <p class="lead">Two front-ends, one source of truth. Developers keep PRs; everyone else gets a form / CTA that lands the same YAML behind the scenes.</p>
+  <div class="flows">
+    <div class="flow"><div class="ft"><b>B · No-code "List your program"</b><span class="kch p0">P0</span></div>
+      <ol><li>Paste product URL → AI auto-drafts the listing</li><li>Review/edit in a friendly form (<b>no YAML shown</b>)</li><li>Email magic-link (no GitHub, no password)</li><li>"Submit for review" → <code>submissions</code> table → status page</li><li>Clean → bot opens PR → CI auto-merges → live in minutes</li><li>Email: "claim &amp; verify for the Verified badge"</li></ol>
+      <div class="note">Makes the "no GitHub needed" promise finally true.</div></div>
+
+    <div class="flow"><div class="ft"><b>D-creator · "Get my link"</b><span class="kch p0">P0</span></div>
+      <ol><li>On <code>/programs/{slug}</code>, CTA branches on <code>powered_by</code></li><li><code>affitor</code> → "Get your affiliate link" → instant tracked link + dashboard + payouts</li><li>External → "Apply" → <code>signup_url</code> (+utm) + "Save to my list"</li><li>Trust: Verified badge, real terms, "Verified by Stripe"</li></ol>
+      <div class="note">Turns the phone book into a marketplace.</div></div>
+
+    <div class="flow"><div class="ft"><b>A · Founder / Developer</b><span class="kch ok">enhance</span></div>
+      <ol><li>GitHub PR fast-lane stays</li><li><code>npx openaffiliate submit</code> auto-drafts + opens PR</li><li>MCP <code>submit_program</code></li><li>Claim + owner dashboard; upsell → run on Affitor</li></ol></div>
+
+    <div class="flow"><div class="ft"><b>C · Network bulk import</b><span class="kch p1">P1</span></div>
+      <ol><li>Network gets an API key / partner account</li><li>Upload CSV/JSON mapped to schema</li><li><code>import-bulk.ts</code> → dedupe-by-domain → one batch PR</li><li>Maintainer reviews batch (no auto-merge &gt; N files)</li></ol></div>
+
+    <div class="flow full"><div class="ft"><b>E · AI agent (both sides)</b><span class="kch p2">P2</span></div>
+      <ol><li>Read tools exist. Add write tools — <code>submit_program</code>, <code>claim_program</code>, <code>get_link</code> — to MCP + CLI + SDK, all proxying the same server intake.</li><li>One canonical pipeline for dev, non-tech human, and agent alike. Makes the AGENTS.md claim true.</li></ol></div>
+  </div>
+</section>
+
+<!-- ARCHITECTURE -->
+<section>
+  <h2>Architecture — keep the open YAML ethos</h2>
+  <p class="lead"><b>Invariant:</b> YAML-in-Git stays the single source of truth. The DB is added <b>only as a staging buffer for un-published state</b> (pending submissions, claim tokens, bulk batches). If the DB vanished, the public registry / API / agents keep working.</p>
+  <div class="arch"><pre>   Developer ─ direct PR ───────────────────────────────────┐
+   Non-tech  ─ POST /api/submit ─┐                           │
+   AI agent  ─ submit_program ───┤                           │
+   Network   ─ import-bulk CLI ──┤                           │
+                                 ▼                           │
+                <span class="key">Supabase STAGING</span> (already wired)            │
+                submissions │ claims   (pending only)        │
+                validate · enrich(shared) · dedup ·          │
+                spam-score · DNS/email claim-verify          │
+                                 │ auto-approve OR /admin     │
+                                 ▼                           │
+                <span class="key">GitHub App bot</span> opens / updates PR ──────────┤
+                                                             ▼
+                <span class="key">GIT = SOURCE OF TRUTH</span>  (programs/*.yaml)
+                                 │ existing pr-programs.yml (dedup·verify·auto-merge)
+                                 ▼
+                build-registry.ts → programs.json   (unchanged)
+                                 ▼
+        Web · REST API · MCP · CLI/SDK · AGENTS.md
+                                 │  /programs/{slug} CTA
+                 powered_by:affitor? ─ yes → affitor.com/p/{slug}  (tracked link)
+                                     └ no  → signup_url (+utm)</pre></div>
+  <div class="keystone"><b>Keystone (do first):</b> write the missing <code>scripts/lib/enrich.ts</code> and import it from <b>both</b> CI and <code>/api/submit</code> so the web path and the PR path enrich/validate identically. Reuse the proven <code>/api/votes</code> + <code>/api/events</code> service-role + IP-hash + honeypot pattern. The whole demand boundary is <b>one additive field</b> — <code>powered_by: affitor</code> — so the open registry never becomes a walled garden.</div>
+</section>
+
+<!-- TRUST + ROADMAP -->
+<section>
+  <h2>Trust model &amp; roadmap</h2>
+  <div class="cols">
+    <div class="panel">
+      <h3>Trust tiers (volume vs curation)</h3>
+      <div class="tier"><span class="b" style="background:var(--muted)"></span><div><b>Community</b> — self-served / auto-discovered, <code>verified:false</code>. Frictionless single submit.</div></div>
+      <div class="tier"><span class="b" style="background:var(--gold)"></span><div><b>Claimed</b> — owner verified via DNS TXT (authoritative) or email-on-domain (fallback) → editable, <code>verified:true</code>.</div></div>
+      <div class="tier"><span class="b" style="background:var(--olive)"></span><div><b>Stripe-verified</b> — Affitor-run, real money flows. "Verified by Stripe" — the payout-credibility anchor.</div></div>
+      <div class="tier"><span class="b" style="background:var(--clay)"></span><div><b>Rules:</b> single submit frictionless; <b>bulk gated by review</b>; precedence owner &gt; network &gt; community. Listing <b>free forever</b> — money only on the Affitor engine.</div></div>
+    </div>
+    <div class="panel">
+      <h3>Roadmap</h3>
+      <table>
+        <tr><td class="ph p0">P0</td><td><b>enrich.ts</b> · <code>/api/submit</code> + submissions table + /admin + bot-PR · no-code <code>/list</code> · demand CTA branch → <b>unlocks B + D-creator</b></td></tr>
+        <tr><td class="ph p1">P1</td><td>Claim/verify (DNS TXT + email) + magic-link identity · agent write tools · owner dashboard → ownership + Verified pipeline</td></tr>
+        <tr><td class="ph p2">P2</td><td>Bulk network import · Affitor flywheel (claim → run on Affitor) · native partner accounts → <b>unlocks C</b> + monetization</td></tr>
+      </table>
+    </div>
+  </div>
+</section>
+
+<!-- INSIGHT -->
+<section>
+  <div class="insight"><p>The <b>discovery</b> layer is mature for all four personas; the <b>transaction</b> layer is missing. Both gaps converge on <b>two primitives — a no-code server intake (form → bot PR) and email magic-link identity.</b> Ship those two and B, C, and D unlock together, with Affitor as the monetized engine the technical and trust-sensitive personas graduate into. Discover (open) → claim (own) → run on Affitor (engine).</p></div>
+</section>
+
+<footer>Plan: <code>docs/onboarding-dual-audience-plan.md</code> · grounded in a code audit of <code>open-affiliate</code> (755 YAML, static, GitHub-PR-only) · 2026-06-14</footer>
+</div>
+<script>
+  document.getElementById('tt').onclick=()=>{const d=!document.documentElement.classList.contains('dark');document.documentElement.classList.toggle('dark',d);localStorage.setItem('theme',d?'dark':'light')};
+</script>
+</body>
+</html>

--- a/docs/sdd-submit-rebuild.md
+++ b/docs/sdd-submit-rebuild.md
@@ -1,0 +1,193 @@
+# SDD — Non-Technical Program Submission (rebuilt `/submit`)
+
+> Status: DRAFT v0.2 · 2026-06-14 · Scope: **P0** of the dual-audience onboarding plan ([onboarding-dual-audience-plan.md](onboarding-dual-audience-plan.md)). Implementation-ready: a fresh session should be able to build this without re-reading source.
+>
+> **v0.2 folds an adversarial architect review.** Key corrections: (1) **no zero-human auto-merge** for anonymous web submissions — they always pass a 1-click `/admin` human gate in P0 (auto-merge stays for trusted dev PRs only); (2) the keystone `enrich.ts` MUST write `enrichment-result.json` in the shape the existing CI reads (`pr-programs.yml:176`); (3) a `/api/webhooks/github` handler closes the state machine (merge→published, CI-fail→back-to-pending, closed→rejected); (4) honeypot + `ADMIN_SECRET` auth are **net-new**, not existing patterns; (5) unique constraint + pending-dedup to kill same-slug races; (6) `/api/autofill` needs explicit `maxDuration` and degrades gracefully (the form works without it).
+
+## 1. Goal & scope
+
+**Goal:** Let a **non-technical** person (Growth/Marketing/BizDev) list an affiliate program on openaffiliate.dev via a simple web form — **no GitHub, no YAML, no jargon** — and have it go live automatically, while **YAML-in-Git stays the single source of truth**.
+
+**In scope (P0):**
+- Rebuilt `/submit` page (the approved mockup: URL → AI auto-fill → plain-language form + live preview → email magic-link → success).
+- `POST /api/autofill` — scrape a URL + LLM-draft the listing fields.
+- `POST /api/submit` + `GET /api/submit/status/[id]` — accept a submission into a `submissions` staging table.
+- Spam/quality pre-filter + `/admin` one-click review.
+- GitHub App "bot" that renders an approved submission → `programs/{slug}.yaml` → opens a PR (then the **existing** `pr-programs.yml` takes over unchanged).
+- `scripts/lib/enrich.ts` — the shared enrichment module CI already expects (currently missing). **Keystone.**
+
+**Out of scope (later phases):** full claim/verify (DNS TXT / email-on-domain) → P1; bulk network import → P2; demand-side "get a link" / Affitor handoff → separate SDD; native partner accounts → Affitor.
+
+**Non-goals:** replacing the developer GitHub-PR path (kept as-is; `/submit` only links out to it), and putting program data in a database (DB is staging-only).
+
+## 2. Current state (the gap, verified in code)
+
+- One real write path = a GitHub PR adding `programs/{slug}.yaml`. Even today's `/submit` (`src/app/submit/page.tsx`) just builds YAML client-side and `window.open()`s GitHub's new-file editor → needs a GitHub account + PR literacy. Non-coder conversion ≈ 0.
+- No backend for programs. 755 static YAML → `registry.json` at build (`scripts/build-registry.ts`). Supabase exists but only for votes/analytics (`supabase/migrations/002–006`), **no `programs`/`users`/`submissions`**.
+- CI `pr-programs.yml` does validate → URL-verify → auto-merge, but calls `scripts/enrich-program.ts` **which does not exist** (swallowed by `|| true`). Dedup/logo/enrich silently skipped.
+- Proven write pattern to copy: `src/app/api/votes/route.ts` + `api/events/route.ts` (Supabase `service_role` + IP-hash + honeypot anti-abuse).
+
+## 3. Architecture
+
+**Invariant:** the DB is a **staging buffer for un-published state only**. The instant a submission is approved it becomes a YAML file in Git via a bot PR; from there Git feeds `registry.json`, the API, MCP, CLI, SEO. If the DB vanished, the public product keeps working.
+
+```
+Non-tech web form ─ POST /api/autofill ─► (scrape URL + LLM draft) ─► prefilled form
+                  ─ POST /api/submit ────► submissions table (status=pending)
+                                              │  validate(schema) · enrich(shared) · dedup · spam-score
+                                              │  ├─ clean  ─► auto-approve
+                                              │  └─ else   ─► /admin one-click review
+                                              ▼ on approve
+                                    GitHub App bot: render YAML → open PR
+                                              ▼
+                          GIT = SOURCE OF TRUTH (programs/*.yaml)
+                                              │ existing pr-programs.yml (dedup·verify·auto-merge·rebuild)
+                                              ▼
+                          build-registry.ts → registry.json  (unchanged)
+                                              ▼
+                       Web · REST API · MCP · CLI/SDK · AGENTS.md
+```
+
+## 4. Data model — `supabase/migrations/007_submissions.sql`
+
+```sql
+create table submissions (
+  id            uuid primary key default gen_random_uuid(),
+  payload       jsonb not null,        -- normalized, schema-shaped program object
+  slug          text not null,         -- proposed slug (derived from name)
+  name          text not null,
+  url           text not null,
+  submitter_email text,                -- magic-link identity (optional but recommended)
+  works_here    boolean default false, -- "I work at this company" → claim candidate (P1)
+  status        text not null default 'pending'
+                  check (status in ('pending','spam','approved','rejected','published')),
+  spam_score    smallint default 0,    -- 0..100, higher = spammier
+  dup_of        text,                  -- matched existing slug, if any
+  pr_url        text,                  -- set when bot opens PR
+  ip_hash       text,
+  source        text default 'web-form',
+  created_at    timestamptz default now(),
+  reviewed_at   timestamptz,
+  reviewed_by   text
+);
+create index on submissions (status);
+create unique index on submissions (slug) where status in ('pending','approved'); -- kill same-slug races (R3)
+-- RLS: service-role only (copy votes/events policy). No public read/write.
+```
+No `users` table in P0 — identity is an emailed magic-link token (signed, stateless JWT or a short-lived row); a full accounts/claims model arrives in P1.
+
+**Anti-race / idempotency (architect R3, M2):** the partial-unique index above prevents two open submissions for the same slug. `dedupe()` must check **both** `registry-index.json` (published programs) **and** open `submissions` rows. `POST /api/submit` is idempotent on `(slug, ip_hash)` — a retry/double-click updates the existing pending row instead of inserting a second.
+
+> Note (architect F2): migrations 002–006 already define `votes`, `events`, `program_stats`, `social_items`, `sift_scores`, `tracking_insights`. Confirm `007` is the next free number before writing.
+
+## 5. The keystone — `scripts/lib/enrich.ts`
+
+A pure module imported by **both** CI (`pr-programs.yml`) and `/api/submit`, so web and PR paths enrich identically.
+- `enrich(raw): Program` — coerce commission rate format (`"50"`→`"50%"`, handle `$`/`varies`), derive `slug` from name, set defaults (`kind`, `source`, `verified:false`, `last_verified_at`), fetch + store logo (best-effort), trim/normalize tags, build `agents.prompt`/`keywords` if absent.
+- `validate(p): {ok, errors}` — **real JSON-Schema validation against `schema/program.schema.json`** (ajv). ⚠️ Architect F6: `build-registry.ts:validateProgram` is only a required-fields + slug-filename check, NOT schema-based — do not assume it covers the schema; build the ajv validator here and have `build-registry.ts` reuse it.
+- `dedupe(p, index): string|null` — match by domain/slug/aliases against `registry-index.json` **and** open `submissions`.
+- `toYaml(p): string` — deterministic YAML serialization (one file/program, filename === slug).
+- **`writeEnrichmentResult(results)` — CRITICAL CONTRACT (architect F8/M4):** `pr-programs.yml:176` reads `enrichment-result.json`; the dead `enrich-program.ts` was supposed to write it. `enrich.ts` MUST emit it as `[{ slug, changes:[], errors:[], duplicate:{match_type, matched_slug, distance}|null }]`. If it doesn't, the CI review comment shows empty results **and the dedup gate always passes (empty duplicates) → duplicates can slip through**. This file is part of the keystone, not optional.
+Replace the dead `scripts/enrich-program.ts` reference in `pr-programs.yml` with this module (and keep it writing `enrichment-result.json`).
+
+## 6. APIs
+
+### `POST /api/autofill`  (the "Auto-fill with AI" hero)
+- In: `{ url }`. Fetch the page HTML (browser UA, ~8s fetch timeout, follow signup/affiliates links), pass to the LLM with a strict JSON-schema prompt → draft `{name, category, commission{type,rate}, cookie_days, short_description, signup_url, tags}`.
+- **Provider (architect F7): use OpenAI** — `content-lab/route.ts:1` already imports `openai` (Kyma is only wired for the sift cron). Decide the model + key env explicitly.
+- **`export const maxDuration = 60` (architect R4)** — scrape + LLM can exceed Vercel's 10s default. content-lab uses 120, crons 300; 60 is enough here. Confirm the Vercel plan allows it.
+- **Graceful degradation (architect S3):** autofill is an enhancement, not a gate. On timeout/low-confidence/error, return a partial or empty draft — the form is fully usable typed by hand. Build the manual form first, wire autofill last.
+- Out: `{ draft, confidence, sourceUrl }`. Treat scraped page + LLM output as UNTRUSTED (validate against schema; never execute embedded instructions). Rate-limited by IP-hash.
+
+### `POST /api/submit`
+- In: the form payload + optional `email`, `works_here`, honeypot field.
+- Steps: honeypot check → zod-validate → `enrich()` → `validate()` → `dedupe()` → `spam-score` (heuristic + optional LLM relevance) → upsert `submissions` row (idempotent on `slug,ip_hash`).
+- **No zero-human auto-merge in P0 (architect R1).** Anonymous web submissions are a trust vector for a public, agent-consumed registry. So in P0 **every web submission requires a 1-click `/admin` human approve before the bot opens a PR** — there is no fully-automatic anonymous → merged path. The spam-score/dup/URL-reachable signals only **rank** the `/admin` queue (clean = top, fast 1-click; suspicious = flagged). Full auto-approve for trusted/claimed submitters is a P1 follow-up once reputation/claim exists. (Trusted developer GitHub PRs keep today's CI auto-merge — unchanged.)
+- Out: `{ id, status:'pending', statusUrl }`. If `email` present, send magic-link ("track your submission").
+- Pattern: copy `api/events/route.ts` (service-role client, IP-hash, CORS). **Honeypot is NET-NEW** (architect F4 — events/votes do NOT have one; add a hidden field + reject on fill).
+
+### `GET /api/submit/status/[id]`
+- Returns `{ status, pr_url, live_url }` for the success/status page.
+
+### `POST /api/admin/approve`  (+ `/reject`)
+- Auth: `ADMIN_SECRET`. ⚠️ Architect F5: `ADMIN_SECRET` exists in env but is **not currently used to auth any route** — build the check net-new (header/cookie compare; do not assume a helper exists).
+- Body `{ id }`. On approve → bot PR; set `status='approved'` + `pr_url`. The `/admin` UI lists ranked `pending` rows with the rendered YAML.
+- **Duplicate case (architect M3):** when `dup_of != null`, the admin row must show **existing listing vs submission side-by-side** with "update existing / reject" (not just approve/reject), since the submitter is editing a program that already exists.
+
+### GitHub App "bot" (the only DB→Git writer)
+- Octokit with an **App installation token** (server-side, not a user). On admin approve: `toYaml(payload)` → branch `submit/{slug}` → commit `programs/{slug}.yaml` → open PR (stamped `submitted_by`, source `web-form`). The **existing** `pr-programs.yml` then validates/verifies/(auto-)merges/rebuilds `registry.json`.
+- Secrets: `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_ID` (Vercel env). Rate-limit aware; on token/rate failure, leave row `approved` and alert (M5) — do not silently drop.
+
+### `POST /api/webhooks/github` — closes the state machine (architect R2/R5 — the biggest gap)
+The flow from `approved` → `published` was hand-waved; spec it explicitly. Subscribe the GitHub App to `pull_request` + `check_suite` events (HMAC `GH_WEBHOOK_SECRET`), match the PR by `pr_url`/branch, and:
+- PR **merged** → `submissions.status='published'`, set `live_url`.
+- CI **URL-verify fails** (`pr-programs.yml` won't auto-merge — `:250`) → `status='pending'` + flag for re-review + notify admin (no zombie "approved" forever).
+- PR **closed unmerged** → `status='rejected'`.
+`GET /api/submit/status/[id]` reads this so the success page reflects reality. (Polling cron is an acceptable fallback if a webhook endpoint is undesirable.)
+
+> **Vercel rebuild note (architect R6):** after merge, Vercel's `prebuild` reruns `build-registry.ts` → `registry.json` on `main` (1–3 min). The CI Step 9 also commits `registry.json` on the PR branch pre-merge — harmless but redundant with the post-merge rebuild; "live in minutes" is accurate but tight. Don't promise "instant."
+
+## 7. Frontend — rebuilt `/submit` (`src/app/submit/page.tsx`)
+
+Implements the approved mockup (`docs/mockups/submit-final.html`). Built from existing shadcn/ui primitives + the dark tokens in `globals.css`.
+
+- **States:** `hero` (giant URL input + "Auto-fill with AI") → `form` (revealed, prefilled) → `success`.
+- **Hero:** URL field → calls `/api/autofill` (shimmer ~1.5–2s) → reveal form prefilled with a green "we pre-filled this" notice.
+- **Form (6 required, plain language):** Program name · Website · Category (select from `lib/programs` categories) · One-line pitch (≤120) · **Commission type pills** (% of every renewal / % of first sale / Fixed $ per sale) + amount · **Cookie pills** (7/30/60/90/Lifetime/Custom). "Add more details (optional)" discloses payout method, signup URL, restrictions. **No YAML/slug/GitHub.**
+- **Live preview** (right, sticky; collapses on mobile): renders the directory card as user types — "This is what affiliates and AI agents will see."
+- **Identity:** email (magic-link, "No password needed") + "I work at this company" → `works_here` (Verified badge later).
+- **Submit → success:** "Submitted! Usually live in minutes." + "what happens next" (review → live → claim & verify via Stripe) + status link.
+- **Dev escape-hatch:** subtle "Developer? List via GitHub →" (header chip + footer only) → `github.com/Affitor/open-affiliate` contributor guide.
+- Remove from old page: `generateYaml`, `openGitHubPR` (`window.open` to GitHub), GitHub-username field, raw YAML preview. Also fix `src/app/docs/submit/page.tsx` + `AGENTS.md` false "no GitHub / agent opens PR" copy.
+
+## 8. Moderation, spam, quality
+
+- Honeypot + IP-hash rate-limit on `/api/autofill` and `/api/submit` (existing pattern).
+- `spam_score` = cheap heuristics (URL reachable, dup, gibberish, banned terms) + optional LLM relevance ("is this a real affiliate program?").
+- In P0 **a human approves every web submission** at `/admin` (1-click for clean ones); signals only rank the queue. Nothing anonymous reaches public Git without a human click. Quarantine lives in `submissions` (not Git). (Trusted auto-approve is P1, gated on claim/reputation.)
+- Trust tiers unchanged: web submissions land `verified:false`; Verified is earned via claim (P1) / Stripe (Affitor). Bulk stays gated (P2).
+
+## 9. Build/CI integration (must not disturb YAML → registry.json)
+
+- `build-registry.ts` + `registry.json` pipeline: **untouched**.
+- `pr-programs.yml`: only change = point the enrich step at `scripts/lib/enrich.ts` (real, replacing the `|| true` no-op). Add a `count > N` auto-merge guard (prep for P2 bulk).
+- New env (Vercel): `GH_APP_ID/PRIVATE_KEY/INSTALLATION_ID`, LLM key (already present), reuse `SUPABASE_SERVICE_ROLE_KEY` + `ADMIN_SECRET`.
+- Schema: no breaking change in P0 (additive `powered_by` etc. deferred to demand SDD).
+
+## 10. Security
+- GitHub App token is server-only; never shipped to client. Form posts only data.
+- Treat scraped page + LLM output as UNTRUSTED (validate against schema; never execute embedded instructions).
+- Magic-link tokens: short TTL, single-use, signed.
+- `/admin` behind `ADMIN_SECRET`; bot PRs are public + auditable.
+
+## 11. Acceptance criteria
+1. A non-technical user lists a program **without ever seeing GitHub/YAML** and it goes live (clean case) within minutes.
+2. `/api/autofill` prefills ≥4 of 6 fields for a typical SaaS affiliates page.
+3. Spam/dup submissions never reach public Git (quarantined in `submissions`).
+4. Approved submission produces a valid `programs/{slug}.yaml` that passes the existing CI (schema + URL verify) and rebuilds `registry.json`.
+5. Developer GitHub path still works; `/submit` no longer dead-ends on GitHub.
+6. `enrich.ts` is used by both CI and `/api/submit` (no divergence).
+
+## 12. Phasing within P0 (build order)
+1. `scripts/lib/enrich.ts` **incl. `enrichment-result.json` writer + ajv validate** (+ wire into `pr-programs.yml`). ← keystone, unblocks everything.
+2. `007_submissions.sql` (unique-slug-while-open) + `POST /api/submit` (idempotent, honeypot) + `GET /status` (copy events route).
+3. GitHub App bot (`lib/github-bot.ts`) + `/api/admin/approve|reject` + thin ranked `/admin` (with dup side-by-side) + `ADMIN_SECRET` auth (net-new).
+4. **`/api/webhooks/github`** — close the state machine (merged→published, CI-fail→pending, closed→rejected). *Do not skip — this is what makes the status page truthful.*
+5. Rebuild `/submit` page (the mockup) **manual form first**, fix docs/AGENTS copy.
+6. `POST /api/autofill` (last; degrades gracefully) — wire into the form's hero.
+7. E2E test: form → submit → `/admin` 1-click approve → bot PR → CI merge → webhook → published/live; spam → quarantine; dup → side-by-side; CI URL-verify fail → back to pending + alert.
+
+## 13. Open questions (owner)
+- Auto-approve threshold `T` + which signals are hard-gates vs soft.
+- Magic-link now, or defer email entirely to P1 and accept anonymous submissions in P0? (Recommend: email optional in P0, required to *edit/claim* in P1.)
+- LLM provider/key for autofill (reuse repo's OpenAI key vs Kyma).
+- `/admin` surface: standalone page vs CLI command for v1.
+
+## 13b. Deferred to P1 (called out so P0 scope is honest)
+- **Edit / withdraw a submission** (architect M1): P0 ships read-only `GET /status`; `PATCH`/`DELETE` via magic-link are P1.
+- **Observability** (architect M5): log submission lifecycle to the project's existing **PostHog**, and alert on bot-PR/token/rate failures. Strongly recommended even in P0 — at minimum console + a failure flag — so `approved`-but-no-PR rows are visible.
+
+## 14. File-by-file
+- NEW `scripts/lib/enrich.ts` (+ writes `enrichment-result.json`, exports ajv `validate`) · `supabase/migrations/007_submissions.sql` · `src/app/api/submit/route.ts` · `src/app/api/submit/status/[id]/route.ts` · `src/app/api/autofill/route.ts` (`maxDuration=60`) · `src/app/api/admin/approve/route.ts` (+ `/reject`) · `src/app/api/webhooks/github/route.ts` · `src/app/admin/page.tsx` · `src/lib/github-bot.ts` (Octokit App).
+- EDIT `src/app/submit/page.tsx` (full rebuild → the mockup) · `.github/workflows/pr-programs.yml` (point enrich at `scripts/lib/enrich.ts`; add `count > N` auto-merge guard) · `scripts/build-registry.ts` (reuse the ajv `validate` from `enrich.ts`) · `src/app/docs/submit/page.tsx` + `AGENTS.md` (fix false "no GitHub / agent opens PR" claims).
+- REUSE `schema/program.schema.json` · `scripts/verify-programs.ts` · `src/app/api/events/route.ts` (service-role + IP-hash pattern — note: NO honeypot there, add it).


### PR DESCRIPTION
## What

Commits seven design artifacts from 2026-06-13/14 that were sitting **untracked** in the working tree, so they survive the repo consolidation.

| File | What it is |
|---|---|
| `docs/onboarding-dual-audience-plan.md` | The 4-persona analysis: today there is exactly one path onto the registry — a GitHub PR — and it is wrong for 3 of the 4 personas. |
| `docs/sdd-submit-rebuild.md` | Implementation-ready spec (DRAFT v0.2) for the non-technical `/submit` rebuild, P0 of that plan. |
| `docs/onboarding-flows.html` | Viewable flow diagrams. |
| `docs/mockups/` | Four `/submit` explorations — ai-first-single, friendly-stepper, split-preview — plus the chosen `submit-final`. |

Documentation only, no code change.

## Why now

These existed on one machine and nowhere else. Part of consolidating onto a single repo: anything that only lives in a working tree gets committed before repos move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)