### PR TITLE
chore: make this repo the source of truth

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,0 +1,52 @@
+name: Release npm packages
+
+# Publishes the public-facing packages (cli, sdk, mcp) from the pro SSOT on
+# every git tag matching v*. Keeps npm keys inside the private repo.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      package:
+        description: "Package to publish (cli | sdk | mcp | all)"
+        required: false
+        default: "all"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      matrix:
+        package: [cli, sdk, mcp]
+    steps:
+      - name: Skip when dispatch targets single package
+        if: ${{ inputs.package != '' && inputs.package != 'all' && inputs.package != matrix.package }}
+        run: echo "skipping ${{ matrix.package }}" && exit 0
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install deps
+        run: npm ci
+
+      - name: Build package
+        working-directory: packages/${{ matrix.package }}
+        run: npm run build
+
+      - name: Publish
+        working-directory: packages/${{ matrix.package }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          npm publish --access public --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,2 +1,1 @@
 @AGENTS.md
-@AGENTS.pro.md

--- a/README.md
+++ b/README.md
@@ -208,8 +208,18 @@ open-affiliate/
   packages/sdk/        # TypeScript SDK (openaffiliate-sdk)
   scripts/             # Build registry, verify URLs
   schema/              # JSON Schema for YAML validation
+  packages/scoring/    # Affiliate Score v1 — the public formula
   .github/             # CI workflows
 ```
+
+This repository is the source of truth. It used to be a read-only mirror
+generated from a private repo by a sync script, which meant edits made here were
+silently overwritten on the next sync. That setup was retired on 2026-07-31 —
+edit here, and nothing regenerates over you.
+
+Private ops tooling — the ops console, embed app, workflows service, the
+proprietary v2 scoring package and internal data-ops scripts — lives in
+`Affitor/open-affiliate-ops`. Nothing in this repo depends on it.
 
 ## Packages
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,8 +4,7 @@ const nextConfig: NextConfig = {
   // cacheComponents disabled: it is incompatible with the ISR route configs
   // (`revalidate` / `dynamicParams`) added in #33 to cap the Apify cost leak,
   // which broke the Turbopack production build. Nothing uses the "use cache"
-  // directive, so disabling is safe and keeps the ISR cost fix. NOTE: mirror
-  // this in the open-affiliate-pro SSOT or the next sync will re-break it.
+  // directive, so disabling is safe and keeps the ISR cost fix.
   typescript: {
     ignoreBuildErrors: true,
   },

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "open-affiliate-pro",
+  "name": "open-affiliate",
   "version": "0.1.0",
   "private": true,
   "workspaces": [
@@ -7,7 +7,7 @@
   ],
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npx tsx scripts/build-registry.ts && (npm run build --workspace @openaffiliate/scoring --if-present || true) && (npm run build --workspace apps/embed --if-present || true)",
+    "prebuild": "npx tsx scripts/build-registry.ts && (npm run build --workspace @openaffiliate/scoring --if-present || true)",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
@@ -19,7 +19,8 @@
     "verify:deep": "npx tsx scripts/verify-deep.ts",
     "verify:deep:unverified": "npx tsx scripts/verify-deep.ts --unverified",
     "sync:public": "npx tsx scripts/sync-to-public.ts",
-    "sync:public:dry": "npx tsx scripts/sync-to-public.ts --dry-run"
+    "sync:public:dry": "npx tsx scripts/sync-to-public.ts --dry-run",
+    "backfill:social": "npx tsx scripts/backfill-social.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",

--- a/scripts/backfill-social.ts
+++ b/scripts/backfill-social.ts
@@ -1,0 +1,75 @@
+/**
+ * One-shot backfill: warm Supabase social_items for the top N programs.
+ *
+ * Why: after switching /programs/[slug] to ISR, build only renders 50 pages.
+ * The rest render on-demand on first visit, which calls Apify and blocks the
+ * user for 5-10s. Running this once seeds the DB so first-visit reads from
+ * Supabase instead.
+ *
+ * Usage:
+ *   set -a && source .env.local && set +a
+ *   npx tsx scripts/backfill-social.ts            # top 50, default
+ *   npx tsx scripts/backfill-social.ts --top=100  # top 100
+ *   npx tsx scripts/backfill-social.ts --all      # every program (expensive)
+ */
+
+import { fetchSocialItems } from "../src/lib/social"
+import { programs, affiliateScore } from "../src/lib/programs"
+
+const CONCURRENCY = 3
+
+function parseArgs(): { top: number; all: boolean } {
+  const args = process.argv.slice(2)
+  const all = args.includes("--all")
+  const topArg = args.find((a) => a.startsWith("--top="))
+  const top = topArg ? parseInt(topArg.split("=")[1], 10) : 50
+  return { top, all }
+}
+
+async function main() {
+  const { top, all } = parseArgs()
+
+  if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    console.error("Missing Supabase env. Source .env.local first.")
+    process.exit(1)
+  }
+  if (!process.env.APIFY_API_KEY && !process.env.RAPIDAPI_KEY) {
+    console.error("Missing APIFY_API_KEY and RAPIDAPI_KEY. Nothing to fetch.")
+    process.exit(1)
+  }
+
+  const target = all
+    ? programs
+    : [...programs].sort((a, b) => affiliateScore(b) - affiliateScore(a)).slice(0, top)
+
+  console.log(`Backfilling ${target.length} programs (concurrency=${CONCURRENCY})`)
+
+  let done = 0
+  let okCount = 0
+  let failCount = 0
+  const start = Date.now()
+
+  for (let i = 0; i < target.length; i += CONCURRENCY) {
+    const batch = target.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(batch.map((p) => fetchSocialItems(p.slug)))
+    for (let j = 0; j < batch.length; j++) {
+      const r = results[j]
+      done++
+      if (r.status === "fulfilled") {
+        okCount++
+        console.log(`[${done}/${target.length}] ${batch[j].slug} → ${r.value.length} items`)
+      } else {
+        failCount++
+        console.log(`[${done}/${target.length}] ${batch[j].slug} → FAILED: ${r.reason}`)
+      }
+    }
+  }
+
+  const secs = Math.round((Date.now() - start) / 1000)
+  console.log(`\nDone in ${secs}s — ok: ${okCount}, failed: ${failCount}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Retires the private-SSOT / generated-mirror split. This repo is now the only one, and edits here stop being silently overwritten by a sync.

## Moved in from `open-affiliate-pro` before it is archived

**`.github/workflows/release-npm.yml`** — it publishes `packages/cli`, `sdk` and `mcp`, **all of which live here**. Its own header says "keeps npm keys inside the private repo". Archiving pro without moving this would have quietly killed npm releases and nobody would have noticed until a release failed.

> ⚠️ **Needs `NPM_TOKEN` added to this repo's secrets** before the next `v*` tag, or the first release after the move fails.

**`scripts/backfill-social.ts`** — imports `src/lib/social` and `src/lib/programs` at compile time, so it can only work here. It was in the private repo where those modules did not exist.

## Leftovers of the mirror arrangement, fixed

| What | Why it mattered |
|---|---|
| `CLAUDE.md` imported `@AGENTS.pro.md` | That file was on the sync blocklist, so it never existed here. The import has been broken the entire time this repo existed. |
| `package.json` named `open-affiliate-pro` | The build log literally printed `> open-affiliate-pro@0.1.0 build`. |
| `prebuild` called `--workspace apps/embed` | A workspace that only existed in the private repo. Every single build printed `npm error No workspaces found` — harmless thanks to `\|\| true`, but it was noise in every log. |
| `next.config.ts` mirror note | Told the reader to mirror the change into "the open-affiliate-pro SSOT or the next sync will re-break it". There is no sync and no SSOT to mirror into. |

## Where the private code went

`Affitor/open-affiliate-ops` (private) — ops console, embed app, workflows service, proprietary v2 scoring, internal data-ops scripts. 82 files, 38 commits, history preserved. **Nothing in this repo depends on it.**

## One thing left open

`@openaffiliate/scoring` is not published to npm, so `packages/scoring-pro` in the ops repo cannot install it cleanly. The package is designed to be public — its header says the formula is transparent so anyone can reproduce a score locally. Adding `scoring` to the matrix in `release-npm.yml` would fix it, but that publishes a **new public npm package**, so I left the matrix alone for you to decide.

## Verification

```
npx tsc --noEmit   0 errors
npm run lint       0 errors, 20 warnings
npm run build      ✓ 878/878 static pages
```

The `apps/embed` workspace error no longer appears in the build log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)