### PR TITLE
feat: add /docs.md and put integration instructions in llms.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ reports/
 /public/llms.txt
 /public/llms-full.txt
 /public/programs.md
+/public/docs.md
 /public/programs/
 /public/categories/
 /public/networks/

--- a/scripts/generate-md.ts
+++ b/scripts/generate-md.ts
@@ -31,6 +31,7 @@ import { mkdirSync, rmSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 
 import registry from "../src/lib/registry.json"
+import { docsNav } from "../src/app/docs/_config"
 
 const BASE = "https://openaffiliate.dev"
 const OUT = join(process.cwd(), "public")
@@ -218,6 +219,92 @@ function groupMd(kind: "category" | "network", label: string, list: Program[]): 
   ])
 }
 
+// ---------- Integration -----------------------------------------------------
+
+/**
+ * How to query the registry live rather than read a snapshot of it. This is
+ * the difference between an agent citing a file and an agent answering from
+ * current data, so it goes in llms.txt itself rather than behind a link.
+ *
+ * Written here rather than lifted from AGENTS.md: that file also carries
+ * repo-development instructions ("this is NOT the Next.js you know") that mean
+ * nothing to an agent consuming the registry.
+ */
+const INTEGRATION = `### MCP — recommended
+
+HTTP, no install:
+
+\`\`\`json
+{ "mcpServers": { "openaffiliate": { "url": "${BASE}/api/mcp" } } }
+\`\`\`
+
+stdio, for local tools:
+
+\`\`\`json
+{ "mcpServers": { "openaffiliate": { "command": "npx", "args": ["-y", "openaffiliate-mcp"] } } }
+\`\`\`
+
+Tools: \`search_programs\` (keyword, category, commission type, verified),
+\`get_program\` (full detail including the recommendation guidance), and
+\`list_categories\`.
+
+### REST — no auth
+
+\`\`\`
+GET ${BASE}/api/programs?q=ai&category=AI&type=recurring&verified=true
+GET ${BASE}/api/programs/{slug}
+GET ${BASE}/api/categories
+\`\`\`
+
+### CLI
+
+\`\`\`bash
+npx openaffiliate search "database" --json
+npx openaffiliate info vercel --json
+npx openaffiliate categories --json
+\`\`\``
+
+// ---------- docs.md ---------------------------------------------------------
+
+/**
+ * An index, not a conversion. The 13 docs pages are hand-written TSX with no
+ * content source to generate from — turning them into markdown means moving
+ * them to MDX first, which is a refactor rather than a generator.
+ *
+ * But docs/_config.ts already holds every page's title, group and description,
+ * and it is the same source the sidebar and prev/next navigation read. That is
+ * enough for a map an agent can navigate, with no second copy of the prose.
+ */
+function docsMd(): string {
+  const groups = docsNav
+    .map(g => {
+      const items = g.items
+        .map(i => `- [${i.title}](${BASE}${i.href})${i.description ? ` — ${i.description}` : ""}`)
+        .join("\n")
+      return `### ${g.label}\n\n${items}`
+    })
+    .join("\n\n")
+
+  return joinSections([
+    `# OpenAffiliate documentation`,
+    [
+      `> How to query the registry from code, an agent, or the terminal.`,
+      `> Pages below are HTML; the registry data itself is available as markdown.`,
+    ].join("\n"),
+    section("Integration", INTEGRATION),
+    section("Pages", groups),
+    section(
+      "Registry as markdown",
+      [
+        `- [Entry point](${BASE}/llms.txt)`,
+        `- [All programs by category](${BASE}/programs.md)`,
+        `- [Full dump](${BASE}/llms-full.txt)`,
+        `- Any program, category or network page, with .md appended`,
+      ].join("\n"),
+    ),
+  ])
+}
+
 // ---------- llms.txt --------------------------------------------------------
 
 function llmsTxt(): string {
@@ -268,13 +355,14 @@ function llmsTxt(): string {
     ),
     section("Categories", catLines),
     section("Networks", netLines),
+    // Querying beats citing: this surface is a snapshot, the API is current.
+    section("Querying this registry", INTEGRATION),
     section(
       "Everything else",
       [
         `- [All programs, grouped by category](${BASE}/programs.md)`,
         `- [Full dump, every program in one file](${BASE}/llms-full.txt)`,
-        `- [JSON API](${BASE}/api/programs) — no auth required`,
-        `- [MCP server](${BASE}/api/mcp) — search_programs, get_program, list_categories`,
+        `- [Documentation index](${BASE}/docs.md)`,
       ].join("\n"),
     ),
     section(
@@ -362,6 +450,7 @@ function main(): void {
   write("llms.txt", llmsTxt())
   write("llms-full.txt", llmsFullTxt())
   write("programs.md", programsIndexMd())
+  write("docs.md", docsMd())
 
   for (const p of programs) {
     write(`programs/${p.slug}.md`, programMd(p))


### PR DESCRIPTION
Phase 2 — done as an **index rather than a conversion**.

## Why not per-page markdown

The 13 docs pages are hand-written TSX with no content source behind them. Emitting a `.md` twin for each means moving them to MDX first — a refactor, not a generator — and it would fork **1733 lines of prose into a second copy that drifts.** The original plan flagged this and was right.

But `docs/_config.ts` already holds every page's title, group and description, and it is the same source the sidebar and prev/next navigation read. That is enough for a map an agent can navigate, with **no second copy of anything.**

## The more useful half

`llms.txt` now carries the integration instructions themselves — MCP config for both HTTP and stdio, the REST endpoints, the CLI commands.

That is the difference between an agent **citing a snapshot** and an agent **querying current data**. Previously `llms.txt` linked to `/api/mcp` and `/api/programs` without saying how to use either.

Written from the facts rather than lifted from `AGENTS.md`, which also carries repo-development instructions ("this is NOT the Next.js you know") that mean nothing to an agent consuming the registry.

## Every claim verified against production first

Publishing wrong instructions in the format agents trust most is the worst failure mode available here, so none of it was assumed:

| Claim | Result |
|---|---|
| `GET /api/programs?q=ai&category=AI&type=recurring&verified=true` | 200 |
| `GET /api/programs/vercel` | 200 |
| `GET /api/categories` | 200 |
| `POST /api/mcp` | 200, SSE, initialize handshake completes |
| `GET /api/mcp` | 405 — correct for a POST-only endpoint |
| `tools/list` | `search_programs`, `get_program`, `list_categories` |
| npm | `openaffiliate@0.0.2`, `openaffiliate-mcp@0.0.3` |

> One thing worth recording: `POST /api/mcp` first appeared to fail with curl code 000. It was not broken — curl was hanging on the held-open SSE stream. Checked properly before writing anything about it.

## Result

792 generated files. `tsc` 0 errors, build 883 static pages, `/public/docs.md` gitignored like the rest of the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)