### PR TITLE
fix: make /explore fast, stop showing dead thumbnails, drop it from nav

### DIFF
--- a/src/components/explore-table.tsx
+++ b/src/components/explore-table.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { ExternalLink, Play, FileText, MessageCircle } from "lucide-react";
 import { ProgramLogo } from "@/components/program-logo";
+import { ExploreThumbnail } from "@/components/explore-thumbnail";
 import type { ExploreItem } from "@/lib/social-explore";
 
 function formatNumber(n: number): string {
@@ -90,18 +91,10 @@ export function ExploreTable({ items }: ExploreTableProps) {
                     rel="noopener noreferrer"
                     className="shrink-0 hidden sm:block"
                   >
-                    {item.thumbnail ? (
-                      <img
-                        src={item.thumbnail}
-                        alt=""
-                        className="h-16 w-28 rounded-lg object-cover bg-muted"
-                        loading="lazy"
-                      />
-                    ) : (
-                      <div className="h-16 w-28 rounded-lg bg-muted/50 flex items-center justify-center">
-                        <PlatformBadge platform={item.platform} />
-                      </div>
-                    )}
+                    <ExploreThumbnail
+                      src={item.thumbnail}
+                      placeholder={<PlatformBadge platform={item.platform} />}
+                    />
                   </a>
                   <div className="min-w-0 flex-1">
                     <a

--- a/src/components/explore-thumbnail.tsx
+++ b/src/components/explore-thumbnail.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Thumbnails come from whatever platform published the content, and a good
+ * number of those URLs are dead — TikTok CDN links expire, YouTube thumbs
+ * disappear with the video. A plain <img> renders those as an empty grey box,
+ * which is most of what a visitor sees on /explore.
+ *
+ * Falls back to the same placeholder used when there is no thumbnail at all,
+ * so a dead link and a missing link look identical instead of broken.
+ */
+export function ExploreThumbnail({
+  src,
+  placeholder,
+}: {
+  src: string | null | undefined;
+  placeholder: React.ReactNode;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  if (!src || failed) {
+    return (
+      <div className="h-16 w-28 rounded-lg bg-muted/50 flex items-center justify-center">
+        {placeholder}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={src}
+      alt=""
+      className="h-16 w-28 rounded-lg object-cover bg-muted"
+      loading="lazy"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -15,9 +15,11 @@ function GitHubIcon({ className }: { className?: string }) {
   );
 }
 
+// Explore is intentionally absent. The page still works at /explore and is
+// linked from content that points at it, but it is not promoted in the nav
+// until its thumbnails and load time are good enough to send people to.
 const NAV_LINKS = [
   { label: "Programs", href: "/programs" },
-  { label: "Explore", href: "/explore" },
   { label: "Rankings", href: "/rankings" },
   { label: "Submit", href: "/submit" },
   { label: "Docs", href: "/docs" },

--- a/src/lib/social-explore.ts
+++ b/src/lib/social-explore.ts
@@ -91,9 +91,14 @@ export async function fetchExploreData(
   const offset = (page - 1) * pageSize
 
   // Build query
+  // "estimated" asks Postgres for the planner's row estimate instead of
+  // scanning the table. social_items holds ~148k rows, and an exact count
+  // meant a full scan on every page load — the single biggest cost on this
+  // page. The number is only ever rendered as "N results", where being off
+  // by a rounding error costs nothing.
   let query = supabase
     .from("social_items")
-    .select("*", { count: "exact" })
+    .select("*", { count: "estimated" })
 
   // Platform filter
   if (filters.platform && filters.platform !== "all") {
@@ -173,9 +178,26 @@ export async function fetchExploreData(
   }
 }
 
+/**
+ * Five more counts on top of the main query, one per platform. They were
+ * exact, so each was its own full scan of a ~148k-row table, and nothing
+ * cached them — six scans per page load, which is why /explore took ~5s cold.
+ *
+ * Estimated counts plus a short in-process cache. These feed the platform
+ * tabs, where the number is a rough sense of scale, not a figure anyone
+ * reconciles.
+ */
+let _platformCounts: { at: number; value: Record<string, number> } | null = null
+const PLATFORM_COUNT_TTL_MS = 10 * 60 * 1000
+
 export async function fetchPlatformCounts(): Promise<
   Record<string, number>
 > {
+  const now = Date.now()
+  if (_platformCounts && now - _platformCounts.at < PLATFORM_COUNT_TTL_MS) {
+    return _platformCounts.value
+  }
+
   const supabase = getSupabase()
   const platforms = ["youtube", "tiktok", "x", "reddit", "blog"]
   const counts: Record<string, number> = {}
@@ -184,11 +206,12 @@ export async function fetchPlatformCounts(): Promise<
     platforms.map(async (p) => {
       const { count } = await supabase
         .from("social_items")
-        .select("id", { count: "exact", head: true })
+        .select("id", { count: "estimated", head: true })
         .eq("platform", p)
       counts[p] = count ?? 0
     })
   )
 
+  _platformCounts = { at: now, value: counts }
   return counts
 }


### PR DESCRIPTION
Explore took ~5s cold and its most visible feature was rows of empty grey boxes. Three separate causes.

## Six full table scans per page load

The main query used `count: "exact"`, and `fetchPlatformCounts` ran **five more exact counts**, one per platform. `social_items` holds ~148k rows, so each was a full scan — and nothing cached them.

Both are now `"estimated"`, which asks Postgres for the planner's row estimate instead of scanning, and the platform counts are cached in-process for 10 minutes. These numbers are only ever rendered as "N results" and as scale on the platform tabs; nobody reconciles them.

```
before (prod)   5.2s cold, 1.14s warm
after  (local)  1.56s cold, 0.12s warm
```

## Dead thumbnails rendered as empty boxes

Thumbnails come from whatever platform published the content, and plenty of those URLs are dead — TikTok CDN links expire, YouTube thumbs go with the video. A plain `<img>` renders those as a grey rectangle, which is most of what a visitor currently sees.

The table is a server component so it could not handle `onError`. `ExploreThumbnail` is a small client component that falls back to **the same placeholder already used when there is no thumbnail at all**, so a dead link and a missing one look identical instead of broken.

## Removed from the nav

The page still works and stays linked from content that points at it. It is just not promoted until it is good enough to send people to.

## Verification

```
tsc 0 errors · build 883 static pages
nav renders: Programs, Rankings, Submit, Docs
/explore: 51 thumbnails across 26 rows, 1 placeholder
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)