### PR TITLE
feat: canonical URLs, entity schema, and an About page

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { programs } from "@/lib/programs";
+
+export const metadata: Metadata = {
+  title: "About",
+  description:
+    "OpenAffiliate is a community-maintained, MIT-licensed registry of affiliate programs. Who runs it, how the data is verified, and how to reach us.",
+  alternates: { canonical: "/about" },
+};
+
+const verified = programs.filter((p) => p.verified).length;
+
+/**
+ * Answer-first: each heading is the question a reader or an AI engine would
+ * ask, and the first sentence under it is the answer. Sites without a
+ * verifiable identity get treated as less trustworthy and cited less, which
+ * is what put this site at 50/100 on trust signals with no About or Contact
+ * anywhere on the domain.
+ */
+export default function AboutPage() {
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-12">
+      <h1 className="text-2xl font-bold tracking-tight">About OpenAffiliate</h1>
+      <p className="mt-3 text-sm text-muted-foreground">
+        OpenAffiliate is an open registry of affiliate programs — one YAML file
+        per program, in public, under an MIT licence. It is built to be read by
+        people and by AI agents alike.
+      </p>
+
+      <h2 className="mt-10 text-lg font-semibold">What is OpenAffiliate?</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        A free, community-maintained directory of {programs.length} affiliate
+        programs. Every entry records the commission rate, cookie window, payout
+        terms, and guidance on when the program is worth recommending. There is
+        no account, no paywall, and no placement fee — position in the rankings
+        cannot be bought.
+      </p>
+
+      <h2 className="mt-8 text-lg font-semibold">
+        How is the data verified?
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {verified} of {programs.length} programs are verified, meaning a
+        maintainer checked the commission terms against the program&apos;s own
+        page and recorded the date. The remaining{" "}
+        {programs.length - verified} are community-submitted and unconfirmed —
+        every program page states its own status and verification date, and so
+        does the machine-readable{" "}
+        <Link href="/llms.txt" className="underline underline-offset-4">
+          llms.txt
+        </Link>
+        . Treat unverified figures as a starting point and check the
+        program&apos;s own page before acting on them.
+      </p>
+
+      <h2 className="mt-8 text-lg font-semibold">Who maintains it?</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        OpenAffiliate is maintained by Affitor together with the contributors
+        who submit and correct programs. Every change lands as a public pull
+        request, so the full edit history of any entry is visible to anyone.
+      </p>
+
+      <h2 className="mt-8 text-lg font-semibold">How do I contact you?</h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        For a correction, a new program, or anything else, open an issue or a
+        pull request on GitHub — that is the fastest route and it keeps the
+        conversation public.
+      </p>
+      <ul className="mt-3 space-y-1.5 text-sm">
+        <li>
+          <a
+            href="https://github.com/Affitor/open-affiliate/issues/new"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4"
+          >
+            Report incorrect data
+          </a>{" "}
+          <span className="text-muted-foreground">
+            — include the program slug and what is wrong
+          </span>
+        </li>
+        <li>
+          <Link href="/submit" className="underline underline-offset-4">
+            Submit a program
+          </Link>{" "}
+          <span className="text-muted-foreground">— add yours to the registry</span>
+        </li>
+        <li>
+          <a
+            href="https://github.com/Affitor/open-affiliate"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline underline-offset-4"
+          >
+            Source code
+          </a>{" "}
+          <span className="text-muted-foreground">— MIT licensed</span>
+        </li>
+      </ul>
+
+      <h2 className="mt-8 text-lg font-semibold">
+        Can I use this data in my own product?
+      </h2>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Yes. The registry is available as a{" "}
+        <Link href="/docs/api" className="underline underline-offset-4">
+          REST API
+        </Link>{" "}
+        with no authentication, an{" "}
+        <Link href="/docs/mcp" className="underline underline-offset-4">
+          MCP server
+        </Link>{" "}
+        for AI agents, a{" "}
+        <Link href="/docs/cli" className="underline underline-offset-4">
+          CLI
+        </Link>
+        , and{" "}
+        <Link href="/llms.txt" className="underline underline-offset-4">
+          markdown surfaces
+        </Link>{" "}
+        for anything that reads text. Attribution is appreciated but not
+        required.
+      </p>
+    </div>
+  );
+}

--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -35,6 +35,7 @@ export async function generateMetadata({
     title,
     description,
     alternates: {
+      canonical: `/categories/${slug}`,
       types: { "text/markdown": `https://openaffiliate.dev/categories/${slug}.md` },
     },
     openGraph: {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,6 +26,14 @@ export const metadata: Metadata = {
   description:
     "Discover, compare, and integrate affiliate programs. Built for developers and AI agents. Open source, community-driven.",
   metadataBase: new URL("https://openaffiliate.dev"),
+  // Self-referencing canonical on every page. Without it, the same listing
+  // reachable at /programs and /programs?page=1 splits its ranking and
+  // citation signals across both. "./" resolves against metadataBase per
+  // route, so each page canonicalises to itself; pages that need something
+  // else override alternates.canonical themselves.
+  alternates: {
+    canonical: "./",
+  },
   openGraph: {
     title: "OpenAffiliate — The Open Registry of Affiliate Programs",
     description:
@@ -129,6 +137,16 @@ function Footer() {
                   Feedback
                 </Link>
               </li>
+              {/* An About page reachable from every page is what turns an
+                  anonymous domain into an identifiable publisher. */}
+              <li>
+                <Link
+                  href="/about"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  About &amp; Contact
+                </Link>
+              </li>
             </ul>
           </div>
         </div>
@@ -154,6 +172,54 @@ function Footer() {
   );
 }
 
+/**
+ * Site-wide entity markup.
+ *
+ * AI engines resolve a brand through schema before they will cite it as a
+ * source. Without an Organization node there was nothing tying openaffiliate.dev
+ * to a name, a logo, or the GitHub and npm identities that prove it is real —
+ * the site scored 33/100 on structured data and 50/100 on trust.
+ *
+ * sameAs is the part that does the work: it links this domain to identities an
+ * engine can already verify independently.
+ */
+const SITE_JSON_LD = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "Organization",
+      "@id": "https://openaffiliate.dev/#organization",
+      name: "OpenAffiliate",
+      url: "https://openaffiliate.dev",
+      logo: "https://openaffiliate.dev/logo.svg",
+      description:
+        "The open registry of affiliate programs. Community-maintained, MIT licensed, built for developers and AI agents.",
+      sameAs: [
+        "https://github.com/Affitor/open-affiliate",
+        "https://www.npmjs.com/package/openaffiliate",
+        "https://www.npmjs.com/package/openaffiliate-mcp",
+      ],
+    },
+    {
+      "@type": "WebSite",
+      "@id": "https://openaffiliate.dev/#website",
+      url: "https://openaffiliate.dev",
+      name: "OpenAffiliate",
+      publisher: { "@id": "https://openaffiliate.dev/#organization" },
+      inLanguage: "en",
+      potentialAction: {
+        "@type": "SearchAction",
+        target: {
+          "@type": "EntryPoint",
+          urlTemplate:
+            "https://openaffiliate.dev/programs?q={search_term_string}",
+        },
+        "query-input": "required name=search_term_string",
+      },
+    },
+  ],
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -165,6 +231,13 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
+      <head>
+        <script
+          type="application/ld+json"
+          suppressHydrationWarning
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(SITE_JSON_LD) }}
+        />
+      </head>
       <body className="min-h-full flex flex-col bg-background text-foreground">
         <PostHogProvider>
           <ThemeProvider>

--- a/src/app/networks/[slug]/page.tsx
+++ b/src/app/networks/[slug]/page.tsx
@@ -35,6 +35,7 @@ export async function generateMetadata({
     title,
     description,
     alternates: {
+      canonical: `/networks/${slug}`,
       types: { "text/markdown": `https://openaffiliate.dev/networks/${slug}.md` },
     },
     openGraph: { title, description, url: `https://openaffiliate.dev/networks/${slug}`, siteName: "OpenAffiliate" },

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -65,7 +65,11 @@ export async function generateMetadata({
     // the agents: guidance in a form it can lift directly. Preferred over
     // putting .md URLs in the sitemap: those are alternate representations of
     // a page, not separate pages to index.
+    // canonical must be repeated here: setting `alternates` at all replaces
+    // the inherited object from the root layout, so declaring only `types`
+    // silently dropped the canonical tag from every program page.
     alternates: {
+      canonical: `/programs/${slug}`,
       types: {
         "text/markdown": `https://openaffiliate.dev/programs/${slug}.md`,
       },
@@ -189,6 +193,15 @@ export default async function ProgramPage({
             description: program.shortDescription,
             url: `https://openaffiliate.dev/programs/${program.slug}`,
             brand: { "@type": "Brand", name: program.name },
+            // Provenance. AI platforms weight recency and discount pages they
+            // cannot date, and they cite anonymous content less. These say who
+            // published the entry and when it was last checked — the same
+            // dates the page and the .md twin already show a reader.
+            ...(program.createdAt ? { datePublished: program.createdAt } : {}),
+            ...(program.lastVerifiedAt
+              ? { dateModified: program.lastVerifiedAt }
+              : {}),
+            publisher: { "@id": "https://openaffiliate.dev/#organization" },
             offers: {
               "@type": "Offer",
               category: "Affiliate Program",


### PR DESCRIPTION
An AI-visibility audit put the site at **72/100**, with the damage concentrated in three sub-scores:

| Sub-score | Before |
|---|---|
| AI Crawler Access | 100 |
| Content & Citability | 79 |
| Machine Readability | 73 |
| **Trust & E-E-A-T** | **50** |
| **Structured Data** | **33** |

Three hard failures, all structural.

## 1. Canonical URL — missing on every page

Nothing declared a canonical anywhere on the domain, so `/programs` and `/programs?page=1` competed as separate pages and split their ranking and citation signals. The root layout now sets a self-referencing canonical that resolves per route.

> This also exposed a bug I introduced earlier this session. Adding `alternates: { types: ... }` for the markdown twins **replaces the inherited alternates object wholesale**, which would have silently dropped the canonical from every program, category and network page. Those three now declare both — caught by checking each page type rather than assuming inheritance.

## 2. No structured data outside program pages

There was no `Organization` or `WebSite` node, so nothing tied the domain to a name, a logo, or any identity an engine can verify.

Added to the root layout as a `@graph`, with **`sameAs` pointing at the GitHub repo and the two published npm packages** — identities an engine can already confirm independently. That is the part that does the work. `WebSite` carries a `SearchAction` so `/programs?q=` is addressable as a search endpoint.

Program JSON-LD gains `datePublished`, `dateModified` from `last_verified_at`, and a `publisher` reference to the Organization node. AI platforms weight recency and discount pages they cannot date.

## 3. No About or Contact anywhere

Sites without a verifiable identity get treated as less trustworthy and cited less. `/about` answers the questions a reader or an engine actually asks — what this is, how the data is verified, who maintains it, how to reach them, whether the data can be reused — with the **answer in the first sentence under each heading**.

It states the verified ratio honestly (49 of 760) rather than implying all 760 are checked. Linked from the footer, so it is reachable from every page.

## Verified against a build

```
canonical present and correct on all 8 page types
homepage: Organization + WebSite + SearchAction, sameAs → github + 2 npm packages
program:  datePublished 2025-12-01, dateModified 2026-04-17
markdown alternate links still render
```

`tsc` 0 errors · build 884 static pages.

## Not in here

The remaining warnings are content-shaped, not structural: question-style headings and answer-first structure on the homepage, and citations with outbound attribution. Those change copy rather than markup and belong in their own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)