### PR TITLE
feat: daily optimisation loop

### DIFF
--- a/docs/internal-loop-spec.md
+++ b/docs/internal-loop-spec.md
@@ -1,0 +1,78 @@
+# Daily optimisation loop — spec
+
+> Status: v1, 2026-08-01. Runs unattended. Son reviews outcomes after the fact,
+> not before each run.
+
+## What it is
+
+A cron job that wakes once a day, measures the site against sources it can
+actually read, and — only when it finds something real — opens a pull request
+and decides for itself whether to merge it.
+
+## Why it exists
+
+Every fix in this repo so far started with a human noticing something. The two
+best finds of this session were invisible to anyone looking at the site: 48
+programs whose logo silently 404'd, and pagination that lost your place on every
+back. Both sat in analytics for weeks. A loop that reads the same sources every
+day catches that class of thing without anyone having to look.
+
+## Sources it reads
+
+| Source | What it answers | Access |
+|---|---|---|
+| PostHog | Web vitals per page, rageclicks, event volume, funnel drop-off | Personal API key in `~/kyma-api/.env` |
+| The live site | Status codes, response times, canonical tags, JSON-LD, broken assets | curl |
+| The repo | Type errors, lint, build, registry drift | local |
+| GitHub | Open community PRs, red CI, stale branches | `gh` |
+
+Ahrefs Site Audit is deliberately not in the list — it returns "Insufficient
+plan" on the current subscription.
+
+## The decision it makes
+
+Each run ends in exactly one of four outcomes, and the reasoning is written to
+the log either way:
+
+1. **Nothing found** — log the measurements and exit. This is the expected
+   outcome most days, and a run that finds nothing is a success, not a failure.
+2. **Found, fixed, merged** — the fix is small, verified, and low-risk: a broken
+   asset, a stale artifact, a missing tag. CI green, merge.
+3. **Found, fixed, left open** — the fix touches product behaviour, copy, or
+   anything a person should look at. PR opened and left for Son.
+4. **Found, not fixed** — the issue is real but the fix needs a decision the
+   loop should not make alone. Logged with the evidence, no PR.
+
+## What it must never do
+
+- Merge anything with red CI. No exceptions, including "the failure looks
+  unrelated".
+- Merge a change to pricing, commission data, or any program's published terms.
+  Wrong commission data costs a partner real money; that stays human-reviewed.
+- Merge anything that touches auth, secrets, or the admin surface.
+- Open a PR with no measurement behind it. Every PR states the number that
+  triggered it and the number after the fix.
+- Delete or rewrite program YAML. Community data is not the loop's to edit.
+- Chase a metric it has not verified is real. A P75 over 36 samples is noise;
+  the loop checks sample size and distinct users before acting, because the
+  first pass of this session's analytics review nearly shipped a fix for three
+  pages whose median was fine.
+
+## Improving itself
+
+If a run finds that its own checks are wrong — a false positive, a blind spot, a
+threshold that fires too often — it edits this spec and the script in the same
+PR as the finding, and says so in the PR body. The loop is allowed to change the
+loop.
+
+## Where it lives
+
+- `scripts/daily-audit.sh` — the cron entrypoint
+- `docs/internal-loop-spec.md` — this file, which the run reads as its brief
+- `~/.openaffiliate-loop/` — logs, one file per run, plus `state.json` carrying
+  what the previous run already reported so the same finding is not raised twice
+
+## Schedule
+
+`17 9 * * *` local. Off the hour on purpose — every scheduled job in the world
+fires at :00.

--- a/scripts/daily-audit-prompt.md
+++ b/scripts/daily-audit-prompt.md
@@ -1,0 +1,42 @@
+You are the daily optimisation loop for openaffiliate.dev, running unattended on
+a cron. Nobody will read your output before you act.
+
+Read `docs/internal-loop-spec.md` first. It is your brief: what to measure, what
+you may merge on your own, and what you must never touch. Follow it exactly.
+
+Read `~/.openaffiliate-loop/state.json` if it exists. It lists findings previous
+runs already reported. Do not raise the same finding twice — if it is still
+open, note that and move on.
+
+Then work through the run:
+
+**1. Measure.** Query PostHog with the personal API key in `~/kyma-api/.env`,
+project 439973, filtered to host `openaffiliate.dev`. Look at web vitals per
+page, rageclicks, and event volume over the last 7 days. Check the live site for
+broken assets, missing tags, and slow paths. Check the repo for type errors,
+lint failures, registry drift, and red CI.
+
+**2. Qualify.** Before treating anything as a finding, check the sample size and
+the number of distinct users behind it, and compare the median against the
+percentile. A bad P75 over 40 samples is usually a tail, not a defect. Say so
+and drop it rather than fixing a phantom. This step exists because the first
+analytics review of this project nearly shipped a fix for three pages whose
+median was fine.
+
+**3. Act.** If you have a real finding with a small, verifiable fix, make it on
+a branch, verify it (tsc, lint, build, and a browser check where behaviour
+changed), and open a PR that states the number that triggered it and the number
+after.
+
+**4. Decide.** Reach one of the four outcomes in the spec and write your
+reasoning into the log, including the case where you found nothing. Merge only
+what the spec permits, and never on red CI.
+
+**5. Improve.** If a check of yours proved wrong, blind, or noisy, fix the spec
+and this prompt in the same PR and say so.
+
+Finally, update `~/.openaffiliate-loop/state.json` with what you found and what
+you did, so tomorrow's run does not repeat you.
+
+Be brief. The log is read by a human catching up, not reviewing. A run that
+finds nothing and says so in three lines is a good run.

--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Daily optimisation loop for openaffiliate.dev.
+#
+# Wakes once a day, measures the site, and opens a PR only when it finds
+# something real. Decides for itself whether to merge. The brief it works from
+# is docs/internal-loop-spec.md — edit that to change what the loop does, not
+# this file, which only sets up the run.
+#
+# Install:  crontab -e  →  17 9 * * * /Users/sonpiaz/open-affiliate/scripts/daily-audit.sh
+# Logs:     ~/.openaffiliate-loop/<date>.log
+# Disable:  touch ~/.openaffiliate-loop/PAUSED
+
+set -uo pipefail
+
+REPO="/Users/sonpiaz/open-affiliate"
+LOOP_HOME="$HOME/.openaffiliate-loop"
+LOG="$LOOP_HOME/$(date +%Y-%m-%d).log"
+
+mkdir -p "$LOOP_HOME"
+
+# A kill switch that does not require editing crontab.
+if [ -f "$LOOP_HOME/PAUSED" ]; then
+  echo "[$(date +%H:%M:%S)] paused, skipping" >> "$LOG"
+  exit 0
+fi
+
+cd "$REPO" || { echo "repo not found at $REPO" >> "$LOG"; exit 1; }
+
+# Start from a clean, current main. A run that begins on a stale or dirty tree
+# produces diffs nobody asked for.
+git fetch --quiet origin
+if [ -n "$(git status --porcelain)" ]; then
+  echo "[$(date +%H:%M:%S)] working tree dirty, skipping run" >> "$LOG"
+  exit 0
+fi
+git checkout --quiet main && git pull --quiet --ff-only
+
+{
+  echo ""
+  echo "════════════════════════════════════════════════════"
+  echo "run start $(date '+%Y-%m-%d %H:%M:%S')  @ $(git rev-parse --short HEAD)"
+  echo "════════════════════════════════════════════════════"
+} >> "$LOG"
+
+# The prompt lives in its own file rather than a heredoc here: macOS ships
+# bash 3.2, which mis-parses a quoted heredoc inside $( ) when the body
+# contains an apostrophe. Keeping it separate also lets the loop revise its
+# own brief without editing this launcher.
+claude -p "$(cat "$REPO/scripts/daily-audit-prompt.md")" >> "$LOG" 2>&1
+
+echo "run end $(date '+%H:%M:%S')" >> "$LOG"

--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -47,6 +47,20 @@ git checkout --quiet main && git pull --quiet --ff-only
 # bash 3.2, which mis-parses a quoted heredoc inside $( ) when the body
 # contains an apostrophe. Keeping it separate also lets the loop revise its
 # own brief without editing this launcher.
-claude -p "$(cat "$REPO/scripts/daily-audit-prompt.md")" >> "$LOG" 2>&1
+PROMPT_FILE="$REPO/scripts/daily-audit-prompt.md"
+
+# Fail loudly. Without this the first real run exited 0 while claude rejected
+# an empty prompt, which would have looked like a clean no-findings day every
+# day until someone read the log.
+if [ ! -f "$PROMPT_FILE" ]; then
+  echo "[$(date +%H:%M:%S)] FATAL: prompt file missing at $PROMPT_FILE" >> "$LOG"
+  exit 1
+fi
+
+claude -p "$(cat "$PROMPT_FILE")" >> "$LOG" 2>&1
+CLAUDE_EXIT=$?
+if [ "$CLAUDE_EXIT" -ne 0 ]; then
+  echo "[$(date +%H:%M:%S)] run failed, claude exited $CLAUDE_EXIT" >> "$LOG"
+fi
 
 echo "run end $(date '+%H:%M:%S')" >> "$LOG"


### PR DESCRIPTION
A cron that wakes once a day, measures the site, and opens a PR **only when it finds something real** — then decides for itself whether to merge.

## Why

Every fix in this repo so far started with a human noticing something. The two best finds of this session were invisible to anyone looking at the site: **48 programs whose logo silently 404'd**, and **pagination that lost your place on every back**. Both sat in analytics for weeks. A loop reading the same sources daily catches that class of thing without anyone having to look.

## Three files

| File | Role |
|---|---|
| `docs/internal-loop-spec.md` | The brief — what it reads, what it may merge alone, what it must never touch |
| `scripts/daily-audit-prompt.md` | The prompt, versioned so the loop can revise its own instructions |
| `scripts/daily-audit.sh` | The cron entrypoint |

## The spec is the interesting part

It names **four possible outcomes** and requires the reasoning to be logged for all of them, including "found nothing" — a quiet run is a success, not a failure.

Hard limits on what may be merged unattended:

- never on red CI, including when the failure "looks unrelated"
- never program commission data — wrong commission data costs a partner real money
- never auth, secrets, or the admin surface
- never a PR without a measurement behind it

It also requires **qualifying a finding before acting on it** — sample size, distinct users, median against percentile. That rule exists because the first analytics pass of this session nearly shipped a fix for three pages whose P75 looked catastrophic and whose median was fine.

And the loop is allowed to change the loop: a check that proves noisy or blind gets fixed in the same PR as the finding that exposed it.

## Two guards, both verified

```
PAUSED file    → kill switch that does not need crontab access
dirty tree     → a run starting on an unclean tree produces diffs nobody asked for
```

## What running it actually caught

I ran it once end to end rather than just reading it, and it failed in a way reading would not have shown: the script checks out `main` before working, `main` did not have the prompt file yet, and **claude rejected the empty prompt while the script exited 0**. Silent success is the worst failure mode for an unattended job — it would have looked like a clean no-findings day, every day, until someone read the log. Now it checks the file exists, exits 1, and reports a non-zero exit from claude.

Two smaller things the same pass surfaced: macOS ships bash 3.2, which mis-parses a quoted heredoc inside `$( )` when the body contains an apostrophe — `bash -n` catches it, running the guards alone does not. And when I tried to test the new missing-prompt path by deleting the file, the dirty-tree guard pre-empted me, which is the guard working as intended.

## Install

```
crontab -e
17 9 * * * /Users/sonpiaz/open-affiliate/scripts/daily-audit.sh
```

Off the hour on purpose — every scheduled job in the world fires at :00.

🤖 Generated with [Claude Code](https://claude.com/claude-code)