### PR TITLE
fix: duplicated brand suffix in 37 titles, missing og:image on 31 pages

### DIFF
--- a/docs/internal-loop-spec.md
+++ b/docs/internal-loop-spec.md
@@ -23,8 +23,36 @@ day catches that class of thing without anyone having to look.
 |---|---|---|
 | PostHog | Web vitals per page, rageclicks, event volume, funnel drop-off | Personal API key in `~/kyma-api/.env` |
 | The live site | Status codes, response times, canonical tags, JSON-LD, broken assets | curl |
+| The rendered `<head>` | Title template collisions, missing `og:image`, missing canonical | curl + the built site on a local port |
 | The repo | Type errors, lint, build, registry drift | local |
 | GitHub | Open community PRs, red CI, stale branches | `gh` |
+
+### Reading the rendered `<head>`
+
+Added 2026-08-01, after the first run found 31 pages sharing with no preview
+image and 9 rendering `… | OpenAffiliate | OpenAffiliate`. Neither was visible
+in analytics, in the build, or in any check the loop had.
+
+Two rules make this surface worth re-checking every run:
+
+- Next.js merges metadata **shallowly**. A route that declares its own
+  `openGraph` block *replaces* the parent's, including the `opengraph-image`
+  the root layout contributes by file convention. Any route with an `openGraph`
+  key and no `images` key and no `opengraph-image.tsx` of its own is silently
+  shipping no preview image.
+- `title` is templated (`%s | OpenAffiliate`), `openGraph.title` is not. A page
+  that spells the brand into its own `title` gets it twice; one that strips it
+  from `openGraph.title` loses it entirely. The two fields are not
+  interchangeable and a fix to one is not a fix to the other.
+
+Check both against the **built** site, not the source. Grepping source files
+found 9 of these; rendering the routes found 28 more, because the dynamic
+`/categories/[slug]` and `/networks/[slug]` routes build their titles at
+request time. Static grep is a starting point, never the verification.
+
+Match the brand suffix (`" | OpenAffiliate"` occurring more than once), not the
+bare word — `/docs` is legitimately titled "What is OpenAffiliate?" and a
+substring check reports it as a defect every run.
 
 Ahrefs Site Audit is deliberately not in the list — it returns "Insufficient
 plan" on the current subscription.
@@ -58,12 +86,41 @@ the log either way:
   first pass of this session's analytics review nearly shipped a fix for three
   pages whose median was fine.
 
+### Qualifying a web-vitals number
+
+A page-level vitals figure is not actionable below **20 samples and 10 distinct
+users**. Under that, widen the window before believing it, and compare the
+median against the percentile — a bad P75 over a good median is a tail.
+
+Worked example from the first run, kept because it is the exact shape of the
+mistake: `/docs` showed LCP p50 3576ms / p75 6551ms over 7 days, which reads
+like a broken page. The sample was 4 events from 3 users. The same query over
+30 days gave p50 830ms / p75 1129ms over 12 events, and curl put the page's
+TTFB at 280ms — the *fastest* on the site. There was nothing to fix. Three
+other candidates died the same way that run: `/programs/copy-ai` INP p75 2700ms
+over 3 samples with a 216ms median, `/programs/userpilot` FCP p50 2740ms from a
+single user, and `/rankings` INP p50 168ms, which is inside the good band.
+
+Cross-check a slow-looking page against curl before treating it as slow. A
+server-side number disagreeing with the field data usually means the field data
+is thin, not that the page is broken.
+
 ## Improving itself
 
 If a run finds that its own checks are wrong — a false positive, a blind spot, a
 threshold that fires too often — it edits this spec and the script in the same
 PR as the finding, and says so in the PR body. The loop is allowed to change the
 loop.
+
+Known-noisy checks, and what to do instead:
+
+- **Registry drift.** `npm run registry:build` rewrites a `generated_at`
+  timestamp on every invocation, so a plain `git status` after it reports drift
+  every single run and means nothing. Compare ignoring that field, and restore
+  the working tree afterwards — the cron entrypoint refuses to run on a dirty
+  tree, so a run that leaves the timestamp modified blocks tomorrow's run.
+- **Lint warnings.** The repo sits at 20 warnings / 0 errors. Only a change in
+  that count is a signal; the standing warnings are not a finding.
 
 ## Where it lives
 

--- a/scripts/daily-audit-prompt.md
+++ b/scripts/daily-audit-prompt.md
@@ -13,15 +13,28 @@ Then work through the run:
 **1. Measure.** Query PostHog with the personal API key in `~/kyma-api/.env`,
 project 439973, filtered to host `openaffiliate.dev`. Look at web vitals per
 page, rageclicks, and event volume over the last 7 days. Check the live site for
-broken assets, missing tags, and slow paths. Check the repo for type errors,
-lint failures, registry drift, and red CI.
+broken assets, missing tags, and slow paths. Read the rendered `<head>` on every
+page type for title-template collisions and missing `og:image` — see the spec,
+this surface is invisible to analytics and to the build. Check the repo for type
+errors, lint failures, registry drift, and red CI.
+
+Verify against the built site on a local port, not against source. The first run
+found 9 bad titles by grepping source and 28 more only by rendering the routes,
+because the dynamic ones build their titles at request time.
 
 **2. Qualify.** Before treating anything as a finding, check the sample size and
 the number of distinct users behind it, and compare the median against the
-percentile. A bad P75 over 40 samples is usually a tail, not a defect. Say so
-and drop it rather than fixing a phantom. This step exists because the first
+percentile. Below 20 samples and 10 distinct users, widen the window before
+believing it. A bad P75 over a good median is a tail, not a defect. Say so and
+drop it rather than fixing a phantom. This step exists because the first
 analytics review of this project nearly shipped a fix for three pages whose
-median was fine.
+median was fine, and the first loop run nearly shipped one for `/docs` on 4
+samples that a 30-day window and a curl both cleared.
+
+Two checks are known-noisy and are not findings on their own: registry drift
+that is only the `generated_at` timestamp, and the repo's standing 20 lint
+warnings. Restore any build churn before you finish — the cron entrypoint
+refuses to run on a dirty tree.
 
 **3. Act.** If you have a real finding with a small, verifiable fix, make it on
 a branch, verify it (tsc, lint, build, and a browser check where behaviour

--- a/src/app/categories/[slug]/page.tsx
+++ b/src/app/categories/[slug]/page.tsx
@@ -28,7 +28,9 @@ export async function generateMetadata({
   if (!category) return { title: "Category Not Found" };
 
   const catPrograms = programs.filter((p) => p.category === category);
-  const title = `${category} Affiliate Programs — ${catPrograms.length} Programs | OpenAffiliate`;
+  // No brand suffix: the root layout's title template appends
+  // " | OpenAffiliate". openGraph.title is not templated, so it adds its own.
+  const title = `${category} Affiliate Programs — ${catPrograms.length} Programs`;
   const description = `Compare ${catPrograms.length} ${category.toLowerCase()} affiliate programs. Find the highest-paying commissions, cookie durations, and payout terms.`;
 
   return {
@@ -39,10 +41,13 @@ export async function generateMetadata({
       types: { "text/markdown": `https://openaffiliate.dev/categories/${slug}.md` },
     },
     openGraph: {
-      title,
+      title: `${title} | OpenAffiliate`,
       description,
       url: `https://openaffiliate.dev/categories/${slug}`,
       siteName: "OpenAffiliate",
+      // Nested metadata is replaced, not merged, so declaring openGraph here
+      // drops the root opengraph-image and these pages shared with no preview.
+      images: ["/opengraph-image"],
     },
   };
 }

--- a/src/app/changelog/page.tsx
+++ b/src/app/changelog/page.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 
 export const metadata: Metadata = {
-  title: "Changelog — OpenAffiliate",
+  title: "Changelog",
   description: "What's new in OpenAffiliate. New features, improvements, and fixes.",
 };
 

--- a/src/app/compare/layout.tsx
+++ b/src/app/compare/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Compare Affiliate Programs — OpenAffiliate",
+  title: "Compare Affiliate Programs",
   description:
     "Compare affiliate programs side-by-side. Commission rates, cookie duration, payout terms, and features at a glance.",
   openGraph: {
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
       "Side-by-side comparison of affiliate programs. Find the best fit for your audience.",
     url: "https://openaffiliate.dev/compare",
     siteName: "OpenAffiliate",
+    // Nested metadata is replaced, not merged, so declaring openGraph here
+    // drops the root opengraph-image and this page shared with no preview.
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/embed/page.tsx
+++ b/src/app/embed/page.tsx
@@ -3,7 +3,7 @@ import type { JSX } from "react"
 import type { Metadata } from "next"
 
 export const metadata: Metadata = {
-  title: "Embed — OpenAffiliate",
+  title: "Embed",
   description:
     "Embed live OpenAffiliate data on your site. SVG badges for READMEs, interactive web components for partner pages. Free for public use, premium tiers unlock advanced features.",
 }

--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -6,7 +6,7 @@ import { ExploreFilters } from "@/components/explore-filters";
 import { ExploreTable } from "@/components/explore-table";
 
 export const metadata: Metadata = {
-  title: "Explore Affiliate Content — OpenAffiliate",
+  title: "Explore Affiliate Content",
   description:
     "Discover top-performing affiliate content across YouTube, TikTok, Reddit, and blogs. Find successful patterns to replicate.",
 };

--- a/src/app/explore/stats/page.tsx
+++ b/src/app/explore/stats/page.tsx
@@ -6,7 +6,7 @@ import { fetchSiftInsights } from "@/lib/sift-stats"
 import { SiftInsightsView } from "@/components/sift-charts"
 
 export const metadata: Metadata = {
-  title: "Content Insights — OpenAffiliate",
+  title: "Content Insights",
   description:
     "Find affiliate opportunities: high-commission programs with low content competition, best platforms and formats, category performance.",
 }

--- a/src/app/networks/[slug]/page.tsx
+++ b/src/app/networks/[slug]/page.tsx
@@ -28,7 +28,9 @@ export async function generateMetadata({
   if (!network) return { title: "Network Not Found" };
 
   const netPrograms = programs.filter((p) => (p.network ?? "in-house") === network);
-  const title = `${network} Affiliate Programs — ${netPrograms.length} Programs | OpenAffiliate`;
+  // No brand suffix: the root layout's title template appends
+  // " | OpenAffiliate". openGraph.title is not templated, so it adds its own.
+  const title = `${network} Affiliate Programs — ${netPrograms.length} Programs`;
   const description = `Browse ${netPrograms.length} affiliate programs on the ${network} network. Compare commissions, cookie duration, and payout terms.`;
 
   return {
@@ -38,7 +40,9 @@ export async function generateMetadata({
       canonical: `/networks/${slug}`,
       types: { "text/markdown": `https://openaffiliate.dev/networks/${slug}.md` },
     },
-    openGraph: { title, description, url: `https://openaffiliate.dev/networks/${slug}`, siteName: "OpenAffiliate" },
+    // images: nested metadata is replaced, not merged, so declaring openGraph
+    // here drops the root opengraph-image and these pages shared with no preview.
+    openGraph: { title: `${title} | OpenAffiliate`, description, url: `https://openaffiliate.dev/networks/${slug}`, siteName: "OpenAffiliate", images: ["/opengraph-image"] },
   };
 }
 

--- a/src/app/networks/page.tsx
+++ b/src/app/networks/page.tsx
@@ -7,7 +7,7 @@ import { ProgramLogo } from "@/components/program-logo";
 import { getNetworkStats, networkToSlug } from "@/lib/programs";
 
 export const metadata: Metadata = {
-  title: "Affiliate Networks — OpenAffiliate",
+  title: "Affiliate Networks",
   description:
     "Compare affiliate networks by program count, average commission, and top programs. PartnerStack, Impact, ShareASale, and more.",
 };

--- a/src/app/programs/layout.tsx
+++ b/src/app/programs/layout.tsx
@@ -2,15 +2,22 @@ import type { Metadata } from "next";
 import { programs } from "@/lib/programs";
 
 export const metadata: Metadata = {
-  title: "Browse Affiliate Programs — OpenAffiliate",
+  // No brand suffix here: the root layout's title template already appends
+  // " | OpenAffiliate". Spelling it out again rendered
+  // "Browse Affiliate Programs — OpenAffiliate | OpenAffiliate".
+  title: "Browse Affiliate Programs",
   description:
     "Search and filter " + programs.length + "+ affiliate programs by category, commission type, and more. Curated, verified, and agent-ready.",
   openGraph: {
+    // openGraph.title is not templated, so it keeps the brand.
     title: "Browse Affiliate Programs — OpenAffiliate",
     description:
       "Search and filter " + programs.length + "+ affiliate programs by category, commission type, and more.",
     url: "https://openaffiliate.dev/programs",
     siteName: "OpenAffiliate",
+    // Nested metadata is replaced, not merged, so declaring openGraph here
+    // drops the root opengraph-image and this page shared with no preview.
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/rankings/layout.tsx
+++ b/src/app/rankings/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Affiliate Program Rankings — Highest Paying Programs | OpenAffiliate",
+  title: "Affiliate Program Rankings — Highest Paying Programs",
   description:
     "Compare the highest-paying affiliate programs ranked by commission rate. Browse rankings by program, network, or category.",
   openGraph: {

--- a/src/app/submit/layout.tsx
+++ b/src/app/submit/layout.tsx
@@ -1,15 +1,20 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Submit an Affiliate Program — OpenAffiliate",
+  // The root layout's title template appends " | OpenAffiliate" already.
+  title: "Submit an Affiliate Program",
   description:
     "Add your affiliate program to the OpenAffiliate registry. Generate a YAML file and submit via GitHub PR.",
   openGraph: {
+    // openGraph.title is not templated, so it keeps the brand.
     title: "Submit an Affiliate Program — OpenAffiliate",
     description:
       "Add your affiliate program to the open registry. Community-reviewed, AI agent-ready.",
     url: "https://openaffiliate.dev/submit",
     siteName: "OpenAffiliate",
+    // Nested metadata is replaced, not merged, so declaring openGraph here
+    // drops the root opengraph-image and this page shared with no preview.
+    images: ["/opengraph-image"],
   },
 };
 


### PR DESCRIPTION
Found by the daily loop's first real run, reading the rendered `<head>` of every page type. Neither defect is visible in analytics, in `tsc`, in lint, or in the build.

## 1. Every title carried the brand twice

The root layout templates `"%s | OpenAffiliate"`. 37 pages also spelled the brand into their own `title`, so it rendered twice:

```
Browse Affiliate Programs — OpenAffiliate | OpenAffiliate
Affiliate Program Rankings — Highest Paying Programs | OpenAffiliate | OpenAffiliate
```

`/rankings` came out at 82 characters, well past where Google truncates. The two worst-hit pages are the two most visited: `/programs` (240 pageviews / 95 users in 7 days) and `/rankings` (67 / 32).

9 were in static files. The other 28 are the dynamic `/categories/[slug]` and `/networks/[slug]` routes, which build their titles at request time — they only appeared once the routes were rendered.

**`openGraph.title` is deliberately left carrying the brand.** It is not templated, so stripping it there would lose the brand, not de-duplicate it. The two fields are not interchangeable.

## 2. 31 pages shared with no preview image

Next.js merges metadata [shallowly](https://nextjs.org/docs/app/api-reference/functions/generate-metadata#merging) — a route declaring its own `openGraph` block *replaces* the parent's, including the `opengraph-image` the root layout contributes by file convention. Eight routes did that without setting `images`:

| Route | Pages | Note |
|---|---|---|
| `/programs` | 1 | most visited page on the site |
| `/submit` | 1 | |
| `/compare` | 1 | |
| `/networks/[slug]` | 8 | |
| `/categories/[slug]` | 20 | |

Routes with their own `opengraph-image.tsx` (root, `/rankings`, `/programs/[slug]`) were unaffected.

## Numbers

| | before | after |
|---|---|---|
| titles with a doubled brand suffix | 37 | 0 |
| indexable pages with no `og:image` | 31 | 0 |

## Verification

`tsc --noEmit` clean · lint unchanged at 20 warnings / 0 errors · `next build` green · all 20 page types re-checked against the built site on a local port, asserting one brand suffix per title, an `og:image` on every page, and the brand still present in every `og:title`.

## Loop self-correction

Per the spec's self-improvement rule, three of the loop's own checks proved wrong this run and are fixed in the same PR:

- **Registry drift is noise.** `registry:build` rewrites a `generated_at` timestamp every invocation, so `git status` reports drift every run and means nothing. Worse, leaving it dirty blocks the next run — the cron entrypoint refuses to start on a dirty tree.
- **A substring match for the brand is a permanent false positive.** `/docs` is legitimately titled "What is OpenAffiliate?". The check must match the suffix.
- **Grepping source is not verification.** It found 9 of 37.

The spec also now carries this run's near-miss as a worked example of the qualification rule: `/docs` showed LCP p50 3576ms / p75 6551ms over 7 days, which reads like a broken page. That was 4 events from 3 users. Over 30 days it was p50 830ms, and curl put its TTFB at 280ms — the fastest page on the site. Three other candidates died the same way. Nothing was shipped for any of them.

---

Left open rather than merged: the `og:image` half is a missing tag, but the title half changes copy that appears in search results, and the spec sends copy to a human.

🤖 Generated with [Claude Code](https://claude.com/claude-code)