### PR TITLE
fix: abort the loop when main is stale or diverged

### DIFF
--- a/scripts/daily-audit.sh
+++ b/scripts/daily-audit.sh
@@ -34,7 +34,19 @@ if [ -n "$(git status --porcelain)" ]; then
   echo "[$(date +%H:%M:%S)] working tree dirty, skipping run" >> "$LOG"
   exit 0
 fi
-git checkout --quiet main && git pull --quiet --ff-only
+# Abort rather than continue on a stale or diverged tree. The && chain used
+# to let a failed pull fall through to the run, which would have audited
+# yesterday's code and reported it as today's. Diverged local main is not
+# hypothetical: this script checks out main itself, so a commit made while it
+# was running can land there by accident.
+if ! git checkout --quiet main; then
+  echo "[$(date +%H:%M:%S)] cannot checkout main, skipping run" >> "$LOG"
+  exit 1
+fi
+if ! git pull --quiet --ff-only; then
+  echo "[$(date +%H:%M:%S)] main has diverged from origin, skipping run" >> "$LOG"
+  exit 1
+fi
 
 {
   echo ""


### PR DESCRIPTION
The setup used `git checkout main && git pull --ff-only` and then carried on regardless of the result. **A failed pull fell through to the run**, which would have audited yesterday's code and reported it as today's — the quiet kind of wrong an unattended job can repeat for weeks.

It is not hypothetical. This script checks out `main` itself, so a commit made in another shell while it is running lands on main by accident. That happened during this session: the watchdog commit went to local main instead of its branch because a test run had switched the checkout underneath it. The next pull then refused to fast-forward — and the old code would have run the audit anyway.

Now each step is checked and the run exits 1 with a reason in the log.

Found by running the loop rather than reading it, which is the third defect that pass has turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)