### PR TITLE
fix: reserve layout for the client-only pages, killing 0.49 CLS

### DIFF
--- a/src/app/explore/page.tsx
+++ b/src/app/explore/page.tsx
@@ -26,10 +26,13 @@ function ExploreShell() {
           Discover top-performing content across platforms. Find patterns that work.
         </p>
       </div>
-      <div className="animate-pulse space-y-4">
+      {/* A viewport tall on purpose: the loaded table is far taller than the
+          old h-64 placeholder, so the swap used to drag the footer down from
+          mid-screen — 0.29 CLS. Reserving the fold keeps the footer off it. */}
+      <div className="animate-pulse space-y-4 min-h-dvh">
         <div className="h-10 rounded-lg bg-muted/30" />
         <div className="h-10 rounded-lg bg-muted/30" />
-        <div className="h-64 rounded-lg bg-muted/30" />
+        <div className="h-96 rounded-lg bg-muted/30" />
       </div>
     </main>
   );

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -167,9 +167,43 @@ function ProgramRowList({ program }: { program: Program }) {
   );
 }
 
+// ProgramsContent reads useSearchParams, so the whole subtree bails out of
+// prerendering. Without a fallback the served HTML had an empty <main>, which
+// left the 430px footer sitting near the top of the viewport until the client
+// filled the list in and shoved it down — 0.53 CLS. The skeleton mirrors the
+// real layout and is a viewport tall, so the footer starts below the fold and
+// the swap shifts nothing that is on screen.
+function ProgramsSkeleton() {
+  return (
+    <div className="mx-auto max-w-6xl px-6 py-10 min-h-dvh">
+      <div className="mb-8">
+        <h1 className="text-2xl font-bold tracking-tight">Programs</h1>
+        <div className="mt-2 h-4 w-72 animate-pulse rounded bg-muted/30" />
+      </div>
+      <div className="mb-4 flex flex-wrap items-center gap-2">
+        {[176, 96, 136, 96, 72, 96].map((w, i) => (
+          <div
+            key={i}
+            className="h-9 animate-pulse rounded-lg bg-muted/30"
+            style={{ width: w }}
+          />
+        ))}
+      </div>
+      <div className="space-y-2">
+        {Array.from({ length: 12 }, (_, i) => (
+          <div
+            key={i}
+            className="h-16 animate-pulse rounded-lg bg-muted/30"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export default function ProgramsPage() {
   return (
-    <Suspense>
+    <Suspense fallback={<ProgramsSkeleton />}>
       <ProgramsContent />
     </Suspense>
   );


### PR DESCRIPTION
**Found by the daily loop on its first real run.** Verified independently before shipping.

## The finding

| Page | CLS P75 | CLS P90 | samples | people |
|---|---|---|---|---|
| **/programs** | **0.485** | **0.669** | 111 | 80 |
| /rankings | 0.152 | 0.246 | 58 | 39 |
| /programs/cursor | 0.003 | 0.023 | 76 | 66 |
| / | 0 | 0.016 | 108 | 90 |

Anything above 0.25 is *poor*. `/programs` is more than double that at P75, across 80 distinct people — not a tail.

## Cause

`ProgramsContent` reads `useSearchParams`, so the whole subtree bails out of prerendering, and `<Suspense>` had **no fallback**. The served HTML carried an empty `<main>` — 1604 bytes — which left the footer sitting near the top of the viewport until the client filled the list in and shoved it down.

That shove is the entire score. `/explore` had the same shape with a placeholder too short for the table that replaced it.

## Fix

Both now render a skeleton that mirrors the real layout and reserves a viewport, so the footer starts below the fold and the swap moves nothing that is on screen.

Measured in a browser:

```
/programs   0.485 → 0.000
/explore    0.290 → 0.000
```

## Why I missed it

My own analytics pass reported **CLS P90 0.032 site-wide and called it good.** That number is diluted — most pageviews are program detail pages, which barely shift, and `/programs` is a severe outlier hiding inside a healthy average.

The loop looked per-page and found it. That is the whole argument for having it.

`tsc` 0 errors · build 884 static pages · 25 programs still render after hydration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)