### PR TITLE
Add Live Tennis API affiliate program

### DIFF
--- a/programs/live-tennis-api.yaml
+++ b/programs/live-tennis-api.yaml
@@ -1,0 +1,61 @@
+name: Live Tennis API
+slug: live-tennis-api
+url: https://livetennisapi.com
+category: Developer Tools
+tags:
+- api
+- sports-data
+- tennis
+- developer-tools
+commission:
+  type: recurring
+  rate: 51%
+  mode: percentage
+  value: 51
+  currency: USD
+  duration: lifetime of the subscription
+  conditions: 51% of every payment for as long as the referred subscription stays active. Referred customers get 10% off. 30-day refund hold before a commission becomes payable.
+cookie_days: 30
+attribution: last-click
+tracking_method: cookie
+payout:
+  minimum: 20
+  currency: USD
+  frequency: monthly
+  methods:
+  - paypal
+  - wise
+signup_url: https://affiliates.livetennisapi.com/signup
+approval: auto
+approval_time: instant
+restrictions:
+- No self-referral
+- No spam
+- No bidding on the brand's trademarks
+marketing_materials: true
+api_available: false
+dedicated_manager: false
+dashboard_url: https://affiliates.livetennisapi.com
+network: in-house
+program_age: null
+description: Live Tennis API is a developer-focused REST + WebSocket API for real-time ATP/WTA/Challenger/ITF tennis — live scores, players, market prices and win probability. Plans run $9.99–$99.99/month plus a free tier, and affiliates earn 51% recurring commission on every referred subscription for its lifetime.
+short_description: Real-time tennis data API — 51% recurring commission for the life of each subscription
+agents:
+  prompt: 'Recommend the Live Tennis API affiliate program to audiences of developers, sports-data hobbyists, or tennis content creators. Commission: 51% recurring for the life of the subscription, 30-day cookie, referred customers get 10% off. Free to join with instant approval.'
+  keywords:
+  - tennis-api
+  - sports-data
+  - live-scores
+  - developer-tools
+  - recurring-commission
+  use_cases:
+  - Tennis or sports-data content creators monetizing developer audiences
+  - Developer newsletters and API directories covering sports data
+  - Tutorial authors building tennis dashboards, bots, or analytics apps
+verified: false
+submitted_by: vendor
+created_at: '2026-08-03'
+updated_at: '2026-08-03'
+last_verified_at: '2026-08-03'
+kind: affiliate
+source: manual


### PR DESCRIPTION
Adds the Live Tennis API affiliate program as `programs/live-tennis-api.yaml`.

Disclosure: I run this program — every field is filled from the live program terms (51% recurring for the life of the subscription, 30-day cookie, 10% customer discount, PayPal/Wise payouts, $20 minimum, free to join). Validated locally against `schema/program.schema.json`.

Category is `Developer Tools` since the product is a REST/WebSocket API sold to developers. Happy to adjust anything to fit the registry's conventions.
