### PR TITLE
fix(seo): remove em-dashes from metadata titles, descriptions, OG alts

### DIFF
--- a/src/app/compare/layout.tsx
+++ b/src/app/compare/layout.tsx
@@ -5,7 +5,7 @@ export const metadata: Metadata = {
   description:
     "Compare affiliate programs side-by-side. Commission rates, cookie duration, payout terms, and features at a glance.",
   openGraph: {
-    title: "Compare Affiliate Programs — OpenAffiliate",
+    title: "Compare Affiliate Programs: OpenAffiliate",
     description:
       "Side-by-side comparison of affiliate programs. Find the best fit for your audience.",
     url: "https://openaffiliate.dev/compare",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,7 +35,7 @@ export const metadata: Metadata = {
     canonical: "./",
   },
   openGraph: {
-    title: "OpenAffiliate — The Open Registry of Affiliate Programs",
+    title: "OpenAffiliate: The Open Registry of Affiliate Programs",
     description:
       "Discover, compare, and integrate affiliate programs. Built for developers and AI agents.",
     url: "https://openaffiliate.dev",

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { programs, categories } from "@/lib/programs";
 
-export const alt = "OpenAffiliate — The Open Registry of Affiliate Programs";
+export const alt = "OpenAffiliate: The Open Registry of Affiliate Programs";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/src/app/programs/[slug]/opengraph-image.tsx
+++ b/src/app/programs/[slug]/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { programs, getProgram , commissionDisplay} from "@/lib/programs";
 
-export const alt = "OpenAffiliate — Affiliate Program Details";
+export const alt = "OpenAffiliate: Affiliate Program Details";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -86,7 +86,7 @@ export async function generateMetadata({
     },
     twitter: {
       card: "summary",
-      title: `${program.name} — ${commissionDisplay(program.commission)} ${program.commission.type}`,
+      title: `${program.name}: ${commissionDisplay(program.commission)} ${program.commission.type}`,
       description,
     },
   };

--- a/src/app/programs/layout.tsx
+++ b/src/app/programs/layout.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
     "Search and filter " + programs.length + "+ affiliate programs by category, commission type, and more. Curated, verified, and agent-ready.",
   openGraph: {
     // openGraph.title is not templated, so it keeps the brand.
-    title: "Browse Affiliate Programs — OpenAffiliate",
+    title: "Browse Affiliate Programs: OpenAffiliate",
     description:
       "Search and filter " + programs.length + "+ affiliate programs by category, commission type, and more.",
     url: "https://openaffiliate.dev/programs",

--- a/src/app/rankings/layout.tsx
+++ b/src/app/rankings/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Affiliate Program Rankings — Highest Paying Programs",
+  title: "Affiliate Program Rankings: Highest Paying Programs",
   description:
     "Compare the highest-paying affiliate programs ranked by commission rate. Browse rankings by program, network, or category.",
   openGraph: {
-    title: "Affiliate Program Rankings — OpenAffiliate",
+    title: "Affiliate Program Rankings: OpenAffiliate",
     description:
       "Compare the highest-paying affiliate programs ranked by commission rate across 349+ programs.",
     url: "https://openaffiliate.dev/rankings",

--- a/src/app/rankings/opengraph-image.tsx
+++ b/src/app/rankings/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from "next/og";
 import { programs, parseCommissionRate , commissionDisplay} from "@/lib/programs";
 
-export const alt = "Affiliate Program Rankings — OpenAffiliate";
+export const alt = "Affiliate Program Rankings: OpenAffiliate";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/src/app/submit/layout.tsx
+++ b/src/app/submit/layout.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
     "Add your affiliate program to the OpenAffiliate registry. Generate a YAML file and submit via GitHub PR.",
   openGraph: {
     // openGraph.title is not templated, so it keeps the brand.
-    title: "Submit an Affiliate Program — OpenAffiliate",
+    title: "Submit an Affiliate Program: OpenAffiliate",
     description:
       "Add your affiliate program to the open registry. Community-reviewed, AI agent-ready.",
     url: "https://openaffiliate.dev/submit",


### PR DESCRIPTION
Owner style rule: no em-dashes in user-facing copy. Sweeps metadata strings (title, description, OG alt exports) across src/app. Comments and body copy untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)