### PR TITLE
feat(analytics): count every /api hit as a PostHog api_request

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,46 @@
+import { type NextFetchEvent, type NextRequest, NextResponse } from "next/server"
+
+// Counts every hit on /api/*, cached or not, as a PostHog `api_request`
+// event. The route handlers cannot do this themselves: responses sit in the
+// CDN cache for an hour, so a handler only ever sees the misses. The proxy
+// runs before the cache, on every request. This is where agent traffic from
+// the skills repo (utm_source=affiliate-skills) becomes visible.
+export const config = { matcher: "/api/:path*" }
+
+const POSTHOG_URL = "https://us.i.posthog.com/i/v0/e/"
+
+export function proxy(request: NextRequest, event: NextFetchEvent) {
+  const key = process.env.NEXT_PUBLIC_POSTHOG_KEY
+  if (key) {
+    const { pathname, searchParams } = request.nextUrl
+    const userAgent = request.headers.get("user-agent") ?? ""
+    const ip = request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? ""
+    event.waitUntil(
+      crypto.subtle
+        .digest("SHA-256", new TextEncoder().encode(`${ip}|${userAgent}`))
+        .then((hash) =>
+          fetch(POSTHOG_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              api_key: key,
+              event: "api_request",
+              // One id per (ip, user-agent) pair, hashed so no raw IP is stored.
+              distinct_id: "api:" + Array.from(new Uint8Array(hash).slice(0, 8), (b) => b.toString(16).padStart(2, "0")).join(""),
+              properties: {
+                path: pathname,
+                q: searchParams.get("q"),
+                utm_source: searchParams.get("utm_source"),
+                src: searchParams.get("src"),
+                user_agent: userAgent,
+                referer: request.headers.get("referer"),
+                $process_person_profile: false,
+              },
+            }),
+          })
+        )
+        .catch(() => {})
+    )
+  }
+  return NextResponse.next()
+}


### PR DESCRIPTION
The API routes sit behind a one-hour CDN cache, so a handler only ever sees misses and agent traffic from the skills repo was invisible. `src/proxy.ts` runs before the cache on every `/api/*` request and sends one anonymous `api_request` event (path, q, utm_source, src, user_agent, referer) with a hashed ip+ua as distinct_id. No person profiles, no raw IPs.

Pairs with Affitor/affiliate-skills#28, which tags the API example URLs with `utm_source=affiliate-skills`.

Verified: eslint clean, tsc clean, `next build` picks up the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qgzZT2G818QEouPNRF9F8